### PR TITLE
Remove a SERVER RESPONSE HEADER from FRONTEND

### DIFF
--- a/frontend/src/hooks/auth.tsx
+++ b/frontend/src/hooks/auth.tsx
@@ -79,7 +79,6 @@ export const AuthenticationProvider = (props: AuthenticationProviderProps) => {
     (config) => {
       if (apiKey !== null) {
         config.headers.Authorization = `Bearer ${apiKey}`;
-        config.headers["Access-Control-Allow-Origin"] = "*";
       }
       return config;
     },


### PR DESCRIPTION
Access-Control-Allow-Origin is a *server header*.