### PR TITLE
Add CORS middleware BEFORE handing off request

### DIFF
--- a/store/app/main.py
+++ b/store/app/main.py
@@ -10,7 +10,6 @@ from fastapi.staticfiles import StaticFiles
 from store.app.api.routers.main import api_router
 from store.settings import settings
 
-
 app = FastAPI()
 
 # Adds CORS middleware.

--- a/store/app/main.py
+++ b/store/app/main.py
@@ -10,7 +10,17 @@ from fastapi.staticfiles import StaticFiles
 from store.app.api.routers.main import api_router
 from store.settings import settings
 
+
 app = FastAPI()
+
+# Adds CORS middleware.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[settings.site.homepage],
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
+    allow_headers=["*"],
+)
 
 FRONTEND_DIR = (Path(__file__).parent / "frontend").resolve()
 if not (FRONTEND_BUILD_DIR := FRONTEND_DIR / "build").exists():
@@ -47,13 +57,3 @@ async def redirect_to_index(full_path: str, request: Request) -> Response:
     if full_path in FRONTEND_OTHER_FILES:
         return await StaticFiles(directory=FRONTEND_BUILD_DIR).get_response(full_path, request.scope)
     return await StaticFiles(directory=FRONTEND_BUILD_DIR).get_response("index.html", request.scope)
-
-
-# Adds CORS middleware.
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=[settings.site.homepage],
-    allow_credentials=True,
-    allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
-    allow_headers=["*"],
-)


### PR DESCRIPTION
This prevented false CORS errors that arose really because the server raised an exception and trying to immediately return a response (preventing the CORS middleware from being added in the first place)