### PR TITLE
Graceful fail

### DIFF
--- a/frontend/src/pages/PartDetails.tsx
+++ b/frontend/src/pages/PartDetails.tsx
@@ -1,3 +1,4 @@
+import { useAlertQueue } from "hooks/alerts";
 import { api, Image } from "hooks/api";
 import { useAuthentication } from "hooks/auth";
 import { useEffect, useState } from "react";
@@ -22,6 +23,7 @@ interface PartDetailsResponse {
 }
 
 const PartDetails = () => {
+  const { addAlert } = useAlertQueue();
   const auth = useAuthentication();
   const auth_api = new api(auth.api);
   const { id } = useParams();
@@ -56,9 +58,9 @@ const PartDetails = () => {
 
   useEffect(() => {
     if (error) {
-      navigate("/404"); // Redirect to a 404 page
+      addAlert(error, "error");
     }
-  }, [error, navigate]);
+  }, [error]);
 
   if (!part) {
     return <Spinner animation="border" />;

--- a/frontend/src/pages/Parts.tsx
+++ b/frontend/src/pages/Parts.tsx
@@ -4,6 +4,7 @@ import { useAuthentication } from "hooks/auth";
 import { useEffect, useState } from "react";
 import { Breadcrumb, Card, Col, Row, Spinner } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
+import { isFulfilled } from "utils/isfullfiled";
 
 const Parts = () => {
   const auth = useAuthentication();
@@ -12,13 +13,6 @@ const Parts = () => {
   const [idMap, setIdMap] = useState<Map<string, string>>(new Map());
   const [error, setError] = useState<string | null>(null);
   const { addAlert } = useAlertQueue();
-
-  // Type guard to check if a result is a fulfilled result
-  function isFulfilled<T>(
-    result: PromiseSettledResult<T>,
-  ): result is PromiseFulfilledResult<T> {
-    return result.status === "fulfilled" && result.value != null;
-  }
 
   useEffect(() => {
     const fetch_parts = async () => {

--- a/frontend/src/pages/RobotDetails.tsx
+++ b/frontend/src/pages/RobotDetails.tsx
@@ -1,3 +1,4 @@
+import { useAlertQueue } from "hooks/alerts";
 import { api, Bom } from "hooks/api";
 import { useAuthentication } from "hooks/auth";
 import { useEffect, useState } from "react";
@@ -13,7 +14,6 @@ import {
 } from "react-bootstrap";
 import Markdown from "react-markdown";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { useAlertQueue } from "hooks/alerts";
 import { isFulfilled } from "utils/isfullfiled";
 
 interface RobotDetailsResponse {
@@ -64,7 +64,11 @@ const RobotDetails = () => {
             quantity: part.quantity,
           };
         });
-        setParts((await Promise.allSettled(parts)).filter(isFulfilled).map((result) => result.value as ExtendedBom));
+        setParts(
+          (await Promise.allSettled(parts))
+            .filter(isFulfilled)
+            .map((result) => result.value as ExtendedBom),
+        );
       } catch (err) {
         if (err instanceof Error) {
           setError(err.message);

--- a/frontend/src/pages/Robots.tsx
+++ b/frontend/src/pages/Robots.tsx
@@ -25,7 +25,13 @@ const Robots = () => {
             return [id, await auth_api.getUserById(id)];
           }),
         );
-        setIdMap(new Map(idMap.filter(isFulfilled).map((result) => result.value as [string, string])));
+        setIdMap(
+          new Map(
+            idMap
+              .filter(isFulfilled)
+              .map((result) => result.value as [string, string]),
+          ),
+        );
       } catch (err) {
         if (err instanceof Error) {
           setError(err.message);

--- a/frontend/src/pages/Robots.tsx
+++ b/frontend/src/pages/Robots.tsx
@@ -3,6 +3,7 @@ import { useAuthentication } from "hooks/auth";
 import { useEffect, useState } from "react";
 import { Breadcrumb, Card, Col, Row, Spinner } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
+import { isFulfilled } from "utils/isfullfiled";
 
 const Robots = () => {
   const auth = useAuthentication();
@@ -19,12 +20,12 @@ const Robots = () => {
         robotsQuery.forEach((robot) => {
           ids.add(robot.owner);
         });
-        const idMap = await Promise.all(
+        const idMap = await Promise.allSettled(
           Array.from(ids).map(async (id) => {
             return [id, await auth_api.getUserById(id)];
           }),
         );
-        setIdMap(new Map(idMap.map(([key, value]) => [key, value])));
+        setIdMap(new Map(idMap.filter(isFulfilled).map((result) => result.value as [string, string])));
       } catch (err) {
         if (err instanceof Error) {
           setError(err.message);

--- a/frontend/src/utils/isfullfiled.ts
+++ b/frontend/src/utils/isfullfiled.ts
@@ -1,0 +1,6 @@
+// Type guard to check if a result is a fulfilled result
+export function isFulfilled<T>(
+  result: PromiseSettledResult<T>,
+): result is PromiseFulfilledResult<T> {
+  return result.status === "fulfilled" && result.value != null;
+}


### PR DESCRIPTION
Some pages (such as Robots, Parts, etc) make several API requests, instead of redirecting to /404 on clientside anytime *any* client OR server error occurs, we ought to just take the good results and run with them