### PR TITLE
Fix #74: Prevent shaking of theme icons on click by adding CSS transitions and positioning

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -8,3 +8,8 @@ div.content {
     gap: 16px;
   }
 }
+
+/* Ensure smooth transitions for theme change */
+body {
+  transition: background-color 0.2s ease, color 0.2s ease;
+}

--- a/frontend/src/components/nav/TopNavbar.css
+++ b/frontend/src/components/nav/TopNavbar.css
@@ -1,0 +1,14 @@
+/* Styles for theme icons to prevent shaking and add smooth transitions */
+.theme-icon {
+  cursor: pointer;
+  position: relative; /* Keep relative to avoid layout shifts */
+  transition: color 0.2s ease; /* Smooth color transition */
+}
+
+.light-mode-icon {
+  color: #201a42;
+}
+
+.dark-mode-icon {
+  color: #f5f2ef;
+}

--- a/frontend/src/components/nav/TopNavbar.tsx
+++ b/frontend/src/components/nav/TopNavbar.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Container, Nav, Navbar } from "react-bootstrap";
 import { GearFill, MoonFill, SunFill } from "react-bootstrap-icons";
 import { Link } from "react-router-dom";
+import "./TopNavbar.css"; // Ensure to import the CSS file
 
 const TopNavbar = () => {
   const [showSidebar, setShowSidebar] = useState<boolean>(false);
@@ -18,11 +19,12 @@ const TopNavbar = () => {
           </Navbar.Brand>
           <div className="d-flex gap-3">
             <Nav.Link
+              className="theme-icon"
               onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
             >
-              {theme === "dark" ? <MoonFill /> : <SunFill />}
+              {theme === "dark" ? <MoonFill className="dark-mode-icon" /> : <SunFill className="light-mode-icon" />}
             </Nav.Link>
-            <Nav.Link onClick={() => setShowSidebar(true)}>
+            <Nav.Link className="theme-icon" onClick={() => setShowSidebar(true)}>
               <GearFill />
             </Nav.Link>
           </div>


### PR DESCRIPTION
**What does this PR do?**

Fixes the shaking of light and dark mode icons when clicked by adding CSS transitions and positioning rules.

**What issues does this PR fix or reference?**

Fixes #74 (addresses the issue of layout shifts causing icon shaking when toggling themes)
