### PR TITLE
Make it so 404 doesn't rewrite the URL

### DIFF
--- a/frontend/src/components/NotFoundRedirect.tsx
+++ b/frontend/src/components/NotFoundRedirect.tsx
@@ -1,12 +1,7 @@
-import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import NotFound from "pages/NotFound";
 
 const NotFoundRedirect = () => {
-  const navigate = useNavigate();
-  useEffect(() => {
-    navigate("/404", { replace: true });
-  }, [navigate]);
-  return null;
+  return <NotFound />;
 };
 
 export default NotFoundRedirect;


### PR DESCRIPTION
Confusing the user so that they don't know what URL they originally were trying to visit is very unfriendly behavior.
