### PR TITLE
Set isAuthenticated to false BEFORE calling API route logout

### DIFF
--- a/frontend/src/pages/Logout.tsx
+++ b/frontend/src/pages/Logout.tsx
@@ -11,8 +11,8 @@ const Logout = () => {
     (async () => {
       deleteLocalStorageAuth();
       try {
-        await auth_api.logout();
         auth.setIsAuthenticated(false);
+        await auth_api.logout();
       } catch (err) {
         console.error(err);
       }


### PR DESCRIPTION
#168 

This is because the API logout route might fail for silly reasons. Now, I am unsure whether the API keys are actually getting deleted serverside (and that is probably a bigger, more fundamental issue as to why the API route is failing - something to do with cross-site issues is my guess), but they are definitely getting deleted client-side.

Now, the entire function is wrapped in a try-catch, which means if the API call fails for whatever reason, the error is caught and we do not procees to set the client-side isAuthenticated state to false.

So this papers over the issue for now /shrug We will have to look into what the logout route is actually doing, because especially if this works, I suspect the answer is that the API route was just failing.