### PR TITLE
Fetch images from artifact ids and render their captions correctly in listing page

### DIFF
--- a/frontend/src/components/files/ViewImage.tsx
+++ b/frontend/src/components/files/ViewImage.tsx
@@ -4,7 +4,7 @@ import React from "react";
 interface ImageProps {
   imageId: string;
   size: "small" | "large";
-  caption: string;
+  caption?: string;
 }
 
 const ImageComponent: React.FC<ImageProps> = ({ imageId, size, caption }) => {

--- a/frontend/src/hooks/api.tsx
+++ b/frontend/src/hooks/api.tsx
@@ -191,6 +191,15 @@ export class api {
     });
   }
 
+  public async getImages(ids: string[]): Promise<Artifact[]> {
+    return this.callWrapper(async () => {
+      const response = await this.api.get("/images/batch", {
+        params: { ids: ids.join(",") },
+      });
+      return response.data;
+    });
+  }
+
   public async uploadImage(formData: FormData): Promise<string> {
     return this.callWrapper(async () => {
       const res = await this.api.post<UploadImageResponse>(

--- a/store/app/crud/artifacts.py
+++ b/store/app/crud/artifacts.py
@@ -65,12 +65,14 @@ class ArtifactsCrud(BaseCrud):
 
     async def upload_image(
         self,
+        name: str,
         image: Image.Image,
         user_id: str,
         description: str | None = None,
     ) -> Artifact:
         artifact = Artifact.create(
             user_id=user_id,
+            name=name,
             artifact_type="image",
             sizes=list(SizeMapping.keys()),
             description=description,
@@ -90,12 +92,14 @@ class ArtifactsCrud(BaseCrud):
 
     async def upload_urdf(
         self,
+        name: str,
         file: io.BytesIO | BinaryIO,
         user_id: str,
         description: str | None = None,
     ) -> Artifact:
         artifact = Artifact.create(
             user_id=user_id,
+            name=name,
             artifact_type="urdf",
             description=description,
         )
@@ -107,12 +111,14 @@ class ArtifactsCrud(BaseCrud):
 
     async def upload_mjcf(
         self,
+        name: str,
         file: io.BytesIO | BinaryIO,
         user_id: str,
         description: str | None = None,
     ) -> Artifact:
         artifact = Artifact.create(
             user_id=user_id,
+            name=name,
             artifact_type="mjcf",
             description=description,
         )

--- a/store/app/crud/listings.py
+++ b/store/app/crud/listings.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 
-from store.app.crud.base import BaseCrud, InternalError, ItemNotFoundError
+from store.app.crud.base import BaseCrud, ItemNotFoundError
 from store.app.model import Artifact, Listing, ListingTag
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ class ListingsCrud(BaseCrud):
         listing_tag = ListingTag.create(listing_id=listing_id, tag=tag)
         return await self._delete_item(listing_tag)
 
-    async def get_urdf_id(
+    async def get_latest_urdf_id(
         self,
         listing_id: str,
     ) -> str | None:
@@ -63,9 +63,4 @@ class ListingsCrud(BaseCrud):
         urdfs = [artifact for artifact in artifacts if artifact.artifact_type == "urdf"]
         if len(urdfs) == 0:
             return None
-        if len(urdfs) > 1:
-            raise InternalError(
-                f"""More than one URDF found for listing {listing_id}.
-                This is due to incorrect data in the database, likely caused by a bug."""
-            )
-        return urdfs[0].id
+        return max(urdfs, key=lambda urdf: urdf.timestamp)

--- a/store/app/model.py
+++ b/store/app/model.py
@@ -5,6 +5,7 @@ methods for converting from our input data into the format the database
 expects (for example, converting a UUID into a string).
 """
 
+import time
 from datetime import datetime, timedelta
 from typing import Literal, Self
 
@@ -103,6 +104,7 @@ class Artifact(RobolistBaseModel):
     artifact_type: ArtifactType
     sizes: list[ArtifactSize] | None = None
     description: str | None = None
+    timestamp: int
 
     @classmethod
     def create(
@@ -120,6 +122,7 @@ class Artifact(RobolistBaseModel):
             artifact_type=artifact_type,
             sizes=sizes,
             description=description,
+            timestamp=int(time.time()),
         )
 
 

--- a/store/app/model.py
+++ b/store/app/model.py
@@ -99,6 +99,7 @@ class Artifact(RobolistBaseModel):
     """
 
     user_id: str
+    name: str
     artifact_type: ArtifactType
     sizes: list[ArtifactSize] | None = None
     description: str | None = None
@@ -107,12 +108,14 @@ class Artifact(RobolistBaseModel):
     def create(
         cls,
         user_id: str,
+        name: str,
         artifact_type: ArtifactType,
         sizes: list[ArtifactSize] | None = None,
         description: str | None = None,
     ) -> Self:
         return cls(
             id=str(new_uuid()),
+            name=name,
             user_id=user_id,
             artifact_type=artifact_type,
             sizes=sizes,

--- a/store/app/routers/image.py
+++ b/store/app/routers/image.py
@@ -50,6 +50,7 @@ async def upload_image(
         image = Image.open(file.file)
         artifact = await crud.upload_image(
             image=image,
+            name=file.filename,
             user_id=user.id,
             description=description,
         )

--- a/store/app/routers/image.py
+++ b/store/app/routers/image.py
@@ -3,14 +3,14 @@
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, status
 from fastapi.responses import RedirectResponse
 from PIL import Image
 from pydantic.main import BaseModel
 
 from store.app.crud.artifacts import get_image_name
 from store.app.db import Crud
-from store.app.model import ArtifactSize, User
+from store.app.model import Artifact, ArtifactSize, User
 from store.app.routers.users import get_session_user_with_write_permission
 from store.settings import settings
 
@@ -64,3 +64,21 @@ async def image_url(image_id: str, size: ArtifactSize) -> RedirectResponse:
     # TODO: Use CloudFront API to return a signed CloudFront URL.
     image_url = f"{settings.site.artifact_base_url}/{get_image_name(image_id, size)}"
     return RedirectResponse(url=image_url)
+
+
+class ImageInfoResponse(BaseModel):
+    id: str
+    caption: str | None
+
+
+@image_router.get("/batch")
+async def batch(
+    crud: Annotated[Crud, Depends(Crud.get)],
+    ids: list[str] = Query(description="List of part ids"),
+) -> list[ImageInfoResponse]:
+    artifacts = await crud._get_item_batch(ids, Artifact)
+    return [
+        ImageInfoResponse(id=artifact.id, caption=artifact.description)
+        for artifact in artifacts
+        if artifact.artifact_type == "image"
+    ]

--- a/store/app/routers/listings.py
+++ b/store/app/routers/listings.py
@@ -36,7 +36,7 @@ async def list_listings(
 
 
 @listings_router.get("/batch")
-async def batch(
+async def get_batch(
     crud: Annotated[Crud, Depends(Crud.get)],
     ids: list[str] = Query(description="List of part ids"),
 ) -> list[Listing]:

--- a/store/app/routers/urdf.py
+++ b/store/app/routers/urdf.py
@@ -54,12 +54,12 @@ async def upload_urdf(
     return UserInfoResponse(urdf_id=artifact.id)
 
 
-@urdf_router.get("/{listing_id}")
+@urdf_router.get("/latest/{listing_id}")
 async def listing_urdf(
     listing_id: str,
     crud: Annotated[Crud, Depends(Crud.get)],
 ) -> RedirectResponse:
-    urdf_id = await crud.get_urdf_id(listing_id)
+    urdf_id = await crud.get_latest_urdf_id(listing_id)
     if urdf_id is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     urdf_url = f"{settings.site.artifact_base_url}/{get_urdf_name(urdf_id)}"

--- a/store/app/routers/urdf.py
+++ b/store/app/routers/urdf.py
@@ -35,6 +35,7 @@ async def upload_urdf(
         )
     artifact = await crud.upload_urdf(
         file=file.file,
+        name=file.filename,
         user_id=user.id,
     )
     return UserInfoResponse(urdf_id=artifact.id)

--- a/store/app/routers/urdf.py
+++ b/store/app/routers/urdf.py
@@ -9,7 +9,7 @@ from pydantic.main import BaseModel
 
 from store.app.crud.artifacts import get_urdf_name
 from store.app.db import Crud
-from store.app.model import User
+from store.app.model import Listing, User
 from store.app.routers.users import get_session_user_with_write_permission
 from store.settings import settings
 
@@ -26,8 +26,20 @@ class UserInfoResponse(BaseModel):
 async def upload_urdf(
     user: Annotated[User, Depends(get_session_user_with_write_permission)],
     crud: Annotated[Crud, Depends(Crud.get)],
+    listing_id: str,
     file: UploadFile,
 ) -> UserInfoResponse:
+    listing = await crud.get_listing(listing_id)
+    if listing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Could not find listing associated with the given id",
+        )
+    if listing.user_id is not user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not own this listing.",
+        )
     if file.content_type != "application/gzip":
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -38,6 +50,7 @@ async def upload_urdf(
         name=file.filename,
         user_id=user.id,
     )
+    await crud._update_item(listing_id, Listing, {"artifact_ids": listing.artifact_ids.append(artifact.id)})
     return UserInfoResponse(urdf_id=artifact.id)
 
 


### PR DESCRIPTION
Resolves #208 
Resolve #195 

- Add route to fetch artifacts in bulk and return only images

- In Listings, fetch images from artifact_ids

    This fixes captions being just "caption" (which was a placeholder
    waiting for this commit) and also fixes trying to render URDF tar
    gunzips.