### PR TITLE
Add Images/STLs labels even when no images/STLs

### DIFF
--- a/frontend/src/components/listing/ListingImages.tsx
+++ b/frontend/src/components/listing/ListingImages.tsx
@@ -48,7 +48,7 @@ const ListingImages = (props: Props) => {
 
   return images.length > 0 || edit ? (
     <div className="flex flex-col items-center justify-center my-4 p-4 relative">
-      {images.length > 0 && (
+      {images.length > 0 ? (
         <>
           <Button
             onClick={() => setCollapsed(!collapsed)}
@@ -89,6 +89,10 @@ const ListingImages = (props: Props) => {
             </div>
           )}
         </>
+      ) : (
+        <p>
+          <strong>Images</strong>
+        </p>
       )}
       {edit && (
         <ListingFileUpload

--- a/frontend/src/components/listing/ListingSTLs.tsx
+++ b/frontend/src/components/listing/ListingSTLs.tsx
@@ -77,7 +77,7 @@ const ListingSTLs = (props: Props) => {
 
   return stls.length > 0 || edit ? (
     <div className="flex flex-col items-center justify-center my-4 p-4 relative">
-      {stls.length > 0 && (
+      {stls.length > 0 ? (
         <>
           <Button
             onClick={() => setCollapsed(!collapsed)}
@@ -114,6 +114,10 @@ const ListingSTLs = (props: Props) => {
             </div>
           )}
         </>
+      ) : (
+        <p>
+          <strong>STLs</strong>
+        </p>
       )}
       {edit && (
         <ListingFileUpload


### PR DESCRIPTION
Improves UI by making it clearer which upload does what, even when there are no images/STLs uploaded yet.

![image](https://github.com/user-attachments/assets/468b4ab6-4be6-44a3-9682-56145e380f64)

Resolves #270 