### PR TITLE
333 sort listings by upvotes and views

### DIFF
--- a/frontend/src/components/footer/Footer.tsx
+++ b/frontend/src/components/footer/Footer.tsx
@@ -85,6 +85,9 @@ const Footer = () => {
             >
               Homepage
             </a>
+            <Link to={"/about"} className="hover:text-gray-500">
+              About
+            </Link>
             <a
               href="https://blog.kscale.dev"
               className="hover:text-gray-500"
@@ -101,9 +104,6 @@ const Footer = () => {
             </Link>
             <Link to={"/tos"} className="hover:text-gray-500">
               Terms of Service
-            </Link>
-            <Link to={"/about"} className="hover:text-gray-500">
-              About
             </Link>
           </div>
           <div className="flex flex-col items-start gap-2 sm:gap-3">

--- a/frontend/src/components/listing/ListingVoteButtons.tsx
+++ b/frontend/src/components/listing/ListingVoteButtons.tsx
@@ -19,7 +19,9 @@ const ListingVoteButtons = ({
   const auth = useAuthentication();
   const { addErrorAlert } = useAlertQueue();
 
-  const handleVote = async (upvote: boolean) => {
+  const handleVote = async (upvote: boolean, event: React.MouseEvent) => {
+    event.stopPropagation();
+
     if (!auth.isAuthenticated) {
       addErrorAlert("You must be logged in to vote");
       return;
@@ -57,7 +59,7 @@ const ListingVoteButtons = ({
   return (
     <div className="flex flex-col items-center mr-4">
       <button
-        onClick={() => handleVote(true)}
+        onClick={(e) => handleVote(true, e)}
         className={`text-2xl ${
           initialUserVote === true ? "text-green-500" : "text-gray-400"
         } hover:text-green-600 transition-colors duration-200`}
@@ -66,7 +68,7 @@ const ListingVoteButtons = ({
       </button>
       <span className="text-lg font-bold my-1">{initialScore}</span>
       <button
-        onClick={() => handleVote(false)}
+        onClick={(e) => handleVote(false, e)}
         className={`text-2xl ${
           initialUserVote === false ? "text-red-500" : "text-gray-400"
         } hover:text-red-600 transition-colors duration-200`}

--- a/frontend/src/components/listing/ListingVoteButtons.tsx
+++ b/frontend/src/components/listing/ListingVoteButtons.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { FaChevronDown, FaChevronUp } from "react-icons/fa";
 
 import { useAlertQueue } from "hooks/useAlertQueue";
@@ -18,6 +19,7 @@ const ListingVoteButtons = ({
 }: ListingVoteButtonsProps) => {
   const auth = useAuthentication();
   const { addErrorAlert } = useAlertQueue();
+  const [isVoting, setIsVoting] = useState(false);
 
   const handleVote = async (upvote: boolean, event: React.MouseEvent) => {
     event.stopPropagation();
@@ -26,6 +28,12 @@ const ListingVoteButtons = ({
       addErrorAlert("You must be logged in to vote");
       return;
     }
+
+    if (isVoting) {
+      return; // Prevent double-clicking
+    }
+
+    setIsVoting(true);
 
     const newVote = initialUserVote === upvote ? null : upvote;
     let scoreDelta;
@@ -53,6 +61,8 @@ const ListingVoteButtons = ({
       addErrorAlert("Failed to submit vote");
       // Revert the optimistic update
       onVoteChange(initialScore, initialUserVote);
+    } finally {
+      setIsVoting(false);
     }
   };
 

--- a/frontend/src/components/listings/ListingGrid.tsx
+++ b/frontend/src/components/listings/ListingGrid.tsx
@@ -50,13 +50,16 @@ const ListingGrid = (props: Props) => {
     </div>
   ) : (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8 mx-auto">
-      {listingIds.map((listingId) => (
-        <ListingGridCard
-          key={listingId}
-          listingId={listingId}
-          listingInfo={listingInfo}
-        />
-      ))}
+      {listingIds.map((listingId) => {
+        const listing = listingInfo?.find((l) => l.id === listingId);
+        return (
+          <ListingGridCard
+            key={listingId}
+            listingId={listingId}
+            listing={listing}
+          />
+        );
+      })}
     </div>
   );
 };

--- a/frontend/src/components/listings/ListingGrid.tsx
+++ b/frontend/src/components/listings/ListingGrid.tsx
@@ -10,11 +10,11 @@ import Spinner from "components/ui/Spinner";
 type ListingInfo =
   paths["/listings/batch"]["get"]["responses"][200]["content"]["application/json"]["listings"];
 
-interface Props {
+interface ListingGridProps {
   listingIds: string[] | null;
 }
 
-const ListingGrid = (props: Props) => {
+const ListingGrid = (props: ListingGridProps) => {
   const { listingIds } = props;
   const auth = useAuthentication();
   const { addErrorAlert } = useAlertQueue();

--- a/frontend/src/components/listings/ListingGridCard.tsx
+++ b/frontend/src/components/listings/ListingGridCard.tsx
@@ -45,8 +45,8 @@ const ListingGridCard = ({ listingId, listing }: Props) => {
       <div
         className={clsx(
           "absolute inset-0 transition-opacity duration-100 ease-in-out",
-          "bg-white dark:bg-black",
-          hovering ? "opacity-20" : "opacity-0",
+          "bg-black dark:bg-white",
+          hovering ? "opacity-10" : "opacity-0",
         )}
       />
 

--- a/frontend/src/components/listings/ListingGridCard.tsx
+++ b/frontend/src/components/listings/ListingGridCard.tsx
@@ -1,51 +1,67 @@
 import { useState } from "react";
+import { FaEye } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 
 import clsx from "clsx";
+import { format } from "date-fns";
 import { paths } from "gen/api";
 
 import ImagePlaceholder from "components/ImagePlaceholder";
-import { Card, CardHeader, CardTitle } from "components/ui/Card";
+import ListingVoteButtons from "components/listing/ListingVoteButtons";
+import { Card, CardFooter, CardHeader, CardTitle } from "components/ui/Card";
 
 type ListingInfo =
-  paths["/listings/batch"]["get"]["responses"][200]["content"]["application/json"]["listings"];
+  paths["/listings/batch"]["get"]["responses"][200]["content"]["application/json"]["listings"][0];
 
 interface Props {
   listingId: string;
-  listingInfo: ListingInfo | null;
+  listing: ListingInfo | undefined;
 }
 
-const ListingGridCard = (props: Props) => {
-  const { listingId, listingInfo } = props;
+const ListingGridCard = ({ listingId, listing }: Props) => {
   const navigate = useNavigate();
   const [hovering, setHovering] = useState(false);
 
-  const listing = listingInfo?.find((listing) => listing.id === listingId);
+  const handleVoteChange = (newScore: number, newUserVote: boolean | null) => {
+    if (listing) {
+      listing.score = newScore;
+      listing.user_vote = newUserVote;
+    }
+  };
 
   return (
     <Card
       className={clsx(
-        "transition-transform duration-100 ease-in-out transform cursor-pointer",
+        "transition-all duration-100 ease-in-out cursor-pointer",
         "flex flex-col max-w-sm rounded material-card bg-white justify-between",
         "dark:bg-gray-900",
-        hovering ? "scale-105" : "scale-100",
+        "relative overflow-hidden",
       )}
       onMouseEnter={() => setHovering(true)}
       onMouseLeave={() => setHovering(false)}
       onClick={() => navigate(`/item/${listingId}`)}
     >
+      {/* Hover overlay */}
+      <div
+        className={clsx(
+          "absolute inset-0 transition-opacity duration-100 ease-in-out",
+          "bg-white dark:bg-black",
+          hovering ? "opacity-20" : "opacity-0",
+        )}
+      />
+
       {listing?.image_url ? (
         <div className="w-full aspect-square bg-white">
           <img
             src={listing.image_url}
             alt={listing.name}
-            className="w-full h-full"
+            className="w-full h-full object-cover"
           />
         </div>
       ) : (
         <ImagePlaceholder />
       )}
-      <div className="px-4 py-4 h-full">
+      <div className="px-4 py-4 h-full flex flex-col justify-between">
         <CardHeader>
           <CardTitle className="text-gray-500 dark:text-gray-300 text-xl min-h-6">
             {listing ? (
@@ -55,6 +71,24 @@ const ListingGridCard = (props: Props) => {
             )}
           </CardTitle>
         </CardHeader>
+        <CardFooter className="flex justify-between items-center">
+          <div className="flex items-center">
+            <FaEye className="mr-1" />
+            <span>{listing?.views || 0}</span>
+          </div>
+          <div className="text-sm text-gray-500">
+            {listing?.created_at &&
+              format(new Date(listing.created_at), "MMM d, yyyy")}
+          </div>
+        </CardFooter>
+      </div>
+      <div className="absolute top-2 left-2 z-10">
+        <ListingVoteButtons
+          listingId={listingId}
+          initialScore={listing?.score ?? 0}
+          initialUserVote={listing?.user_vote ?? null}
+          onVoteChange={handleVoteChange}
+        />
       </div>
     </Card>
   );

--- a/frontend/src/components/ui/Input/Input.tsx
+++ b/frontend/src/components/ui/Input/Input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<
     <input
       type={type}
       className={cn(
-        "flex h-10 w-full rounded-md border border-input px-3 py-2 text-sm ring-offset-background file:border-0 bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-10 w-full rounded-md border border-input px-3 py-2 text-sm ring-offset-background file:border-0 bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       ref={ref}

--- a/frontend/src/components/ui/Select/Select.tsx
+++ b/frontend/src/components/ui/Select/Select.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { type VariantProps, cva } from "class-variance-authority";
 import { cn } from "utils";
 
 export interface SelectOption {
@@ -7,18 +8,39 @@ export interface SelectOption {
   label: string;
 }
 
-interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+const selectVariants = cva(
+  "flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "border-input",
+        outline: "border-2",
+      },
+      size: {
+        default: "h-10 px-3 py-2",
+        sm: "h-8 px-2 py-1 text-xs",
+        lg: "h-11 px-4 py-2",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+interface SelectProps
+  extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, "size">,
+    VariantProps<typeof selectVariants> {
   options: SelectOption[];
+  variant?: "default" | "outline";
 }
 
 const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
-  ({ className, options, ...props }, ref) => {
+  ({ className, options, variant = "default", size, ...props }, ref) => {
     return (
       <select
-        className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
-          className,
-        )}
+        className={cn(selectVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       >
@@ -34,4 +56,4 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
 
 Select.displayName = "Select";
 
-export { Select };
+export { Select, selectVariants };

--- a/frontend/src/components/ui/Select/Select.tsx
+++ b/frontend/src/components/ui/Select/Select.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+import { cn } from "utils";
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  options: SelectOption[];
+}
+
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, options, ...props }, ref) => {
+    return (
+      <select
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    );
+  },
+);
+
+Select.displayName = "Select";
+
+export { Select };

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -1023,6 +1023,11 @@ export interface components {
             /** Onshape Url */
             onshape_url: string | null;
         };
+        /**
+         * SortOption
+         * @enum {string}
+         */
+        SortOption: "newest" | "most_viewed" | "most_upvoted";
         /** UpdateArtifactRequest */
         UpdateArtifactRequest: {
             /** Name */
@@ -1513,7 +1518,7 @@ export interface operations {
                 /** @description Search query string */
                 search_query?: string;
                 /** @description Sort option for listings */
-                sort_by?: string;
+                sort_by?: components["schemas"]["SortOption"];
             };
             header?: never;
             path?: never;

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -870,6 +870,10 @@ export interface components {
             id: string;
             /** User Id */
             user_id: string;
+            /** Created At */
+            created_at: number;
+            /** Updated At */
+            updated_at: number;
             /** Name */
             name: string;
             /** Child Ids */
@@ -1495,11 +1499,13 @@ export interface operations {
     };
     list_listings_listings_search_get: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Page number for pagination */
-                page: number;
+                page?: number;
                 /** @description Search query string */
                 search_query?: string;
+                /** @description Sort option for listings */
+                sort_by?: string;
             };
             header?: never;
             path?: never;

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -917,6 +917,14 @@ export interface components {
             image_url: string | null;
             /** Onshape Url */
             onshape_url: string | null;
+            /** Created At */
+            created_at: number;
+            /** Views */
+            views: number;
+            /** Score */
+            score: number;
+            /** User Vote */
+            user_vote: boolean | null;
         };
         /** LoginRequest */
         LoginRequest: {

--- a/frontend/src/pages/Browse.tsx
+++ b/frontend/src/pages/Browse.tsx
@@ -65,6 +65,18 @@ const Browse = () => {
     <>
       <div className="pb-8">
         <div className="flex justify-center mt-4 gap-x-2">
+          <div>
+            <Select
+              value={sortOption}
+              onChange={(e) => setSortOption(e.target.value)}
+              options={[
+                { value: "newest", label: "Newest" },
+                { value: "most_viewed", label: "Most Viewed" },
+                { value: "most_upvoted", label: "Most Upvoted" },
+              ]}
+              variant="default"
+            />
+          </div>
           <div className="relative">
             <Input
               onChange={(e) => {
@@ -91,18 +103,9 @@ const Browse = () => {
               </div>
             )}
           </div>
-          <Select
-            value={sortOption}
-            onChange={(e) => setSortOption(e.target.value)}
-            options={[
-              { value: "newest", label: "Newest" },
-              { value: "most_viewed", label: "Most Viewed" },
-              { value: "most_upvoted", label: "Most Upvoted" },
-            ]}
-          />
           <Button
             onClick={() => navigate(`/create`)}
-            variant="secondary"
+            variant="primary"
             size="lg"
           >
             Create

--- a/frontend/src/pages/Browse.tsx
+++ b/frontend/src/pages/Browse.tsx
@@ -45,6 +45,7 @@ const Browse = () => {
           page: pageNumber,
           search_query: searchQuery,
           sort_by: sortOption as SortOption,
+          include_user_vote: true,
         },
       },
     });

--- a/frontend/src/pages/Browse.tsx
+++ b/frontend/src/pages/Browse.tsx
@@ -5,10 +5,12 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { useDebounce } from "@uidotdev/usehooks";
 import { useAlertQueue } from "hooks/useAlertQueue";
 import { useAuthentication } from "hooks/useAuth";
+import { SortOption } from "types/listings";
 
 import ListingGrid from "components/listings/ListingGrid";
 import { Button } from "components/ui/Button/Button";
 import { Input } from "components/ui/Input/Input";
+import { Select } from "components/ui/Select/Select";
 
 const Browse = () => {
   const auth = useAuthentication();
@@ -28,10 +30,11 @@ const Browse = () => {
 
   const [searchQuery, setSearchQuery] = useState(query || "");
   const debouncedSearch = useDebounce(searchQuery, 300);
+  const [sortOption, setSortOption] = useState("newest");
 
   useEffect(() => {
     handleSearch();
-  }, [debouncedSearch, pageNumber]);
+  }, [debouncedSearch, pageNumber, sortOption]);
 
   const handleSearch = async () => {
     setListingIds(null);
@@ -41,6 +44,7 @@ const Browse = () => {
         query: {
           page: pageNumber,
           search_query: searchQuery,
+          sort_by: sortOption as SortOption,
         },
       },
     });
@@ -86,6 +90,15 @@ const Browse = () => {
               </div>
             )}
           </div>
+          <Select
+            value={sortOption}
+            onChange={(e) => setSortOption(e.target.value)}
+            options={[
+              { value: "newest", label: "Newest" },
+              { value: "most_viewed", label: "Most Viewed" },
+              { value: "most_upvoted", label: "Most Upvoted" },
+            ]}
+          />
           <Button
             onClick={() => navigate(`/create`)}
             variant="secondary"

--- a/frontend/src/types/listings.ts
+++ b/frontend/src/types/listings.ts
@@ -1,0 +1,5 @@
+export enum SortOption {
+  NEWEST = "newest",
+  MOST_VIEWED = "most_viewed",
+  MOST_UPVOTED = "most_upvoted",
+}

--- a/store/app/crud/listings.py
+++ b/store/app/crud/listings.py
@@ -73,7 +73,7 @@ class ListingsCrud(ArtifactsCrud, BaseCrud):
         search_query: str | None = None,
     ) -> tuple[list[T], bool]:
         logger.info(f"Getting listings - page: {page}, search_query: {search_query}, sort_key: {sort_key}")
-        table = await self.db.Table(self._get_table_name(item_class))
+        table = await self.db.Table(self._get_table_name(Listing))
 
         scan_params = {}
         if search_query:

--- a/store/app/crud/listings.py
+++ b/store/app/crud/listings.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 from enum import Enum
-from typing import Any
+from typing import Any, Callable, Dict, Type
 
 from boto3.dynamodb.conditions import Attr
 
@@ -43,7 +43,7 @@ class ListingsCrud(ArtifactsCrud, BaseCrud):
             logger.error(f"Error in get_listings: {str(e)}")
             raise
 
-    def _get_sort_function(self, sort_by: SortOption):
+    def _get_sort_function(self, sort_by: SortOption) -> Callable[[Dict[str, Any]], Any]:
         if sort_by == SortOption.NEWEST:
             return lambda x: (x.get("created_at") or 0, x.get("id", ""))
         elif sort_by == SortOption.MOST_VIEWED:
@@ -54,7 +54,11 @@ class ListingsCrud(ArtifactsCrud, BaseCrud):
             return lambda x: x.get("id", "")
 
     async def _list(
-        self, model_class, page: int, sort_function, search_query: str | None = None
+        self,
+        model_class: Type[Any],
+        page: int,
+        sort_function: Callable[[Dict[str, Any]], Any],
+        search_query: str | None = None,
     ) -> tuple[list[Any], bool]:
         table = await self.db.Table(self._get_table_name(model_class))
 

--- a/store/app/model.py
+++ b/store/app/model.py
@@ -343,6 +343,8 @@ class Listing(StoreBaseModel):
     """
 
     user_id: str
+    created_at: int
+    updated_at: int
     name: str
     child_ids: list[str]
     description: str | None = None
@@ -364,6 +366,8 @@ class Listing(StoreBaseModel):
         return cls(
             id=new_uuid(),
             user_id=user_id,
+            created_at=int(time.time()),
+            updated_at=int(time.time()),
             name=name,
             child_ids=child_ids,
             description=description,


### PR DESCRIPTION
Notes:
1. TODO: Fix `created_at` date for listing

**What does this PR do?**

Adds a dropdown menu to `/browse` page that allows users to sort listings by:
1. newest
2. most viewed
3. most upvoted

**What issues does this PR fix or reference?**

#333 

**If this PR changes the UI, include a screenshot below.**

<img width="1251" alt="Screenshot 2024-08-28 at 11 34 59 PM" src="https://github.com/user-attachments/assets/65361b94-8913-4a53-a9da-7a0865041308">

