### PR TITLE
Duplicate Listings in Profile Section resolved

### DIFF
--- a/frontend/src/components/pages/Profile.tsx
+++ b/frontend/src/components/pages/Profile.tsx
@@ -285,19 +285,12 @@ const Profile = () => {
   }
 
   return user ? (
-    <>
-      <RenderProfile
-        user={user}
-        onUpdateProfile={handleUpdateProfile}
-        canEdit={canEdit}
-        listingIds={listingIds}
-      />
-      {listingIds && (
-        <div className="mt-4">
-          <ListingGrid listingIds={listingIds} />
-        </div>
-      )}
-    </>
+    <RenderProfile
+      user={user}
+      onUpdateProfile={handleUpdateProfile}
+      canEdit={canEdit}
+      listingIds={listingIds}
+    />
   ) : (
     <div className="flex justify-center items-center pt-8">
       <p>User not found</p>


### PR DESCRIPTION
**What does this PR do?**

This PR fixes the duplicate display of the "Listings" section on the Profile page.

**What issues does this PR fix or reference?**

This PR resolves issue #389, where the "Listings" section is appearing twice on the Profile page

**If this PR changes the UI, include a screenshot below.**

![Screenshot from 2024-09-12 12-07-11](https://github.com/user-attachments/assets/c2f16e14-0253-47a2-8dfa-1523024f953e)
