### PR TITLE
fixes #381: fix select menu background color on browse page

### DIFF
--- a/frontend/src/components/ui/Select/Select.tsx
+++ b/frontend/src/components/ui/Select/Select.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 import { type VariantProps, cva } from "class-variance-authority";
 
 const selectVariants = cva(
-  "flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50",
+  "flex h-10 w-full rounded-md border border-input bg-gray-1 px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50",
   {
     variants: {
       variant: {


### PR DESCRIPTION
**What does this PR do?**

This PR fixes the background color of the dropdown menu associated with the select element on the browse page.

**What issues does this PR fix or reference?**

#381 

**If this PR changes the UI, include a screenshot below.**

![screenshot_select_menu_fix](https://github.com/user-attachments/assets/6d52a34e-7833-4cd0-baed-044872705eb6)

