### PR TITLE
Presigned URLs to Download Kernel Image

### DIFF
--- a/frontend/src/components/DownloadKernelImage.tsx
+++ b/frontend/src/components/DownloadKernelImage.tsx
@@ -11,6 +11,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { components } from "@/gen/api";
 import { useAlertQueue } from "@/hooks/useAlertQueue";
+import { useAuthentication } from "@/hooks/useAuth";
 import axios from "axios";
 import { Download } from "lucide-react";
 
@@ -23,8 +24,14 @@ interface Props {
 const DownloadKernelImage = ({ kernelImage }: Props) => {
   const { addErrorAlert } = useAlertQueue();
   const [isDownloading, setIsDownloading] = useState(false);
+  const auth = useAuthentication();
 
   const handleDownload = async () => {
+    if (!auth.isAuthenticated) {
+      addErrorAlert("Please log in to download kernel images");
+      return;
+    }
+
     setIsDownloading(true);
     try {
       const response = await axios.get(
@@ -74,10 +81,14 @@ const DownloadKernelImage = ({ kernelImage }: Props) => {
         <Button
           className="w-full"
           onClick={handleDownload}
-          disabled={isDownloading}
+          disabled={isDownloading || !auth.isAuthenticated}
         >
           <Download className="mr-2 h-4 w-4" />
-          {isDownloading ? "Downloading..." : "Download"}
+          {isDownloading
+            ? "Downloading..."
+            : auth.isAuthenticated
+              ? "Download"
+              : "Login to Download"}
         </Button>
       </CardFooter>
     </Card>

--- a/frontend/src/components/DownloadKernelImage.tsx
+++ b/frontend/src/components/DownloadKernelImage.tsx
@@ -30,8 +30,10 @@ const DownloadKernelImage = ({ kernelImage }: Props) => {
       const response = await axios.get(
         `/api/kernel-images/download/${kernelImage.id}`,
       );
-      const downloadUrl = response.data;
-      window.location.href = downloadUrl;
+
+      const presignedUrl = response.data;
+
+      window.location.href = presignedUrl;
     } catch (error) {
       console.error("Error downloading kernel image:", error);
       addErrorAlert("Error downloading kernel image");

--- a/store/app/routers/kernel_images.py
+++ b/store/app/routers/kernel_images.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from store.app.db import Crud
 from store.app.model import User
 from store.app.routers.users import (
-    get_session_user,
+    get_session_user_with_read_permission,
     get_session_user_with_write_permission,
     maybe_get_user_from_api_key,
 )
@@ -168,7 +168,7 @@ async def list_public_kernel_images(
 async def download_kernel_image(
     kernel_image_id: str,
     crud: Annotated[Crud, Depends(Crud.get)],
-    user: Annotated[User, Depends(get_session_user)],
+    user: Annotated[User, Depends(get_session_user_with_read_permission)],
 ) -> str:
     kernel_image = await crud.get_kernel_image(kernel_image_id)
     if kernel_image is None:

--- a/store/app/routers/kernel_images.py
+++ b/store/app/routers/kernel_images.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from store.app.db import Crud
 from store.app.model import User
 from store.app.routers.users import (
+    get_session_user,
     get_session_user_with_write_permission,
     maybe_get_user_from_api_key,
 )
@@ -167,12 +168,12 @@ async def list_public_kernel_images(
 async def download_kernel_image(
     kernel_image_id: str,
     crud: Annotated[Crud, Depends(Crud.get)],
-    user: Annotated[User | None, Depends(maybe_get_user_from_api_key)],
+    user: Annotated[User, Depends(get_session_user)],
 ) -> str:
     kernel_image = await crud.get_kernel_image(kernel_image_id)
     if kernel_image is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Kernel image not found")
-    if not kernel_image.is_public and (user is None or user.id != kernel_image.user_id):
+    if not kernel_image.is_public and user.id != kernel_image.user_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="You do not have permission to download this kernel image"
         )


### PR DESCRIPTION
**What does this PR do?**
Presigned URL for S3 file download. Users should be able to download kernel image files from downloads page.

only allow authenticated users to download for now
- can potentially change later once rate limiting/other safeguards are implemented
