### PR TITLE
Kernel Image Download Cleanup

### DIFF
--- a/frontend/src/components/DownloadKernelImage.tsx
+++ b/frontend/src/components/DownloadKernelImage.tsx
@@ -49,12 +49,17 @@ const DownloadKernelImage = ({ kernelImage, onEdit, onDelete }: Props) => {
 
     setIsDownloading(true);
     try {
+      console.log(
+        `Requesting download URL for kernel image ID: ${kernelImage.id}`,
+      );
       const response = await axios.get(
         `/api/kernel-images/download/${kernelImage.id}`,
       );
 
       const presignedUrl = response.data;
+      console.log(`Received presigned URL: ${presignedUrl}`);
 
+      // Open the URL in a new tab
       window.open(presignedUrl, "_blank");
     } catch (error) {
       console.error("Error downloading kernel image:", error);

--- a/frontend/src/components/modals/EditKernelImageModal.tsx
+++ b/frontend/src/components/modals/EditKernelImageModal.tsx
@@ -37,12 +37,13 @@ export const EditKernelImageModal = ({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await onEdit({
+    const updatedData: Partial<KernelImageResponse> = {
       name,
       description,
       is_public: isPublic,
       is_official: isOfficial,
-    });
+    };
+    await onEdit(updatedData);
     onOpenChange(false);
   };
 

--- a/frontend/src/components/pages/Download.tsx
+++ b/frontend/src/components/pages/Download.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import DownloadKernelImage from "@/components/DownloadKernelImage";
 import LoadingArtifactCard from "@/components/listing/artifacts/LoadingArtifactCard";
-import { UploadModal } from "@/components/modals/UploadModal";
+import { UploadKernelImageModal } from "@/components/modals/UploadKerenlImageModal";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -215,7 +215,7 @@ export default function DownloadsPage() {
       </div>
 
       {canUpload && (
-        <UploadModal
+        <UploadKernelImageModal
           isOpen={isUploadModalOpen}
           onClose={() => setIsUploadModalOpen(false)}
           onUpload={handleUpload}

--- a/store/app/crud/kernel_images.py
+++ b/store/app/crud/kernel_images.py
@@ -2,10 +2,8 @@
 
 import io
 import logging
-from typing import TypedDict
+from typing import IO, TypedDict
 
-import boto3
-from botocore.config import Config
 from botocore.exceptions import ClientError
 from fastapi import UploadFile
 
@@ -75,7 +73,11 @@ class KernelImagesCrud(BaseCrud):
                 raise ValueError("Kernel image not found")
 
             # If the name is being updated, we need to rename the S3 object
-            if "name" in valid_updates and valid_updates["name"] != kernel_image.name:
+            if (
+                "name" in valid_updates
+                and isinstance(valid_updates["name"], str)
+                and valid_updates["name"] != kernel_image.name
+            ):
                 old_s3_filename = f"{kernel_image.id}/{kernel_image.name}"
                 new_s3_filename = f"{kernel_image.id}/{valid_updates['name']}"
                 await self._rename_s3_object(old_s3_filename, new_s3_filename)
@@ -83,16 +85,16 @@ class KernelImagesCrud(BaseCrud):
             await self._update_item(kernel_image_id, KernelImage, valid_updates)
 
     async def _rename_s3_object(self, old_filename: str, new_filename: str) -> None:
-        s3_client = boto3.client("s3")
         try:
-            # Copy the object to a new key
-            s3_client.copy_object(
+            # Use self.s3 instead of aioboto3.client
+            await self.s3.meta.client.copy_object(
                 Bucket=settings.s3.bucket,
                 CopySource=f"{settings.s3.bucket}/{settings.s3.prefix}{old_filename}",
                 Key=f"{settings.s3.prefix}{new_filename}",
             )
-            # Delete the old object
-            s3_client.delete_object(Bucket=settings.s3.bucket, Key=f"{settings.s3.prefix}{old_filename}")
+            await self.s3.meta.client.delete_object(
+                Bucket=settings.s3.bucket, Key=f"{settings.s3.prefix}{old_filename}"
+            )
         except ClientError as e:
             logger.error(f"Error renaming object in S3: {e}")
             raise
@@ -122,16 +124,27 @@ class KernelImagesCrud(BaseCrud):
 
     async def get_kernel_image_download_url(self, kernel_image: KernelImage) -> str:
         s3_filename = f"{kernel_image.id}/{kernel_image.name}"
+        logger.info(f"Generating presigned URL for S3 filename: {s3_filename}")
+
+        # Check if the object exists in S3
+        try:
+            await self.s3.meta.client.head_object(Bucket=settings.s3.bucket, Key=f"{settings.s3.prefix}{s3_filename}")
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "404":
+                logger.error(f"S3 object not found: {s3_filename}")
+                raise ValueError(f"S3 object not found: {s3_filename}")
+            else:
+                logger.error(f"Error checking S3 object: {str(e)}")
+                raise
+
         return await self._get_presigned_url(s3_filename)
 
     async def _get_presigned_url(self, s3_filename: str) -> str:
-        s3_client = boto3.client(
-            "s3",
-            config=Config(signature_version="s3v4"),
-            region_name=settings.s3.region,
-        )
         try:
-            presigned_url = s3_client.generate_presigned_url(
+            logger.info(
+                f"Generating presigned URL for S3 bucket: {settings.s3.bucket}, key: {settings.s3.prefix}{s3_filename}"
+            )
+            presigned_url = await self.s3.meta.client.generate_presigned_url(
                 "get_object",
                 Params={
                     "Bucket": settings.s3.bucket,
@@ -139,15 +152,29 @@ class KernelImagesCrud(BaseCrud):
                 },
                 ExpiresIn=3600,  # URL expires in 1 hour
             )
+            logger.info(f"Generated presigned URL: {presigned_url}")
+            return presigned_url
         except ClientError as e:
             logger.error(f"Error generating presigned URL: {e}")
             raise
-        return presigned_url
 
     async def _delete_from_s3(self, s3_filename: str) -> None:
-        s3_client = boto3.client("s3")
         try:
-            s3_client.delete_object(Bucket=settings.s3.bucket, Key=f"{settings.s3.prefix}{s3_filename}")
+            # Use self.s3 instead of aioboto3.client
+            await self.s3.meta.client.delete_object(Bucket=settings.s3.bucket, Key=f"{settings.s3.prefix}{s3_filename}")
         except ClientError as e:
             logger.error(f"Error deleting object from S3: {e}")
+            raise
+
+    async def _upload_to_s3(self, data: IO[bytes], name: str, filename: str, content_type: str) -> None:
+        try:
+            # Use self.s3 instead of aioboto3.client
+            await self.s3.meta.client.upload_fileobj(
+                data,
+                settings.s3.bucket,
+                f"{settings.s3.prefix}{filename}",
+                ExtraArgs={"ContentType": content_type},
+            )
+        except ClientError as e:
+            logger.error(f"Error uploading file to S3: {e}")
             raise


### PR DESCRIPTION
**What does this PR do?**
Address needed functionality and QOL bugs in #445 
1. Delete also needs to delete file from S3 bucket
2. Edit needs to also change name of s3 artifact/file else retrieval breaks?
3. Fix duplicate creation bug (multiple clicks to create during upload process)

Adds logging statements frontend and backend to debug kernel image download via pre-signed urls.