### PR TITLE
466: Website UI nits

### DIFF
--- a/frontend/src/components/nav/Navbar.tsx
+++ b/frontend/src/components/nav/Navbar.tsx
@@ -33,30 +33,32 @@ const Navbar = () => {
       name: "Discord",
       path: "https://discord.gg/kscale",
       icon: <FaDiscord className="h-5 w-5" />,
-      // description:
-      //   "Connect with other robot developers, researchers, and enthusiasts.",
+      description:
+        "",
     },
     {
       name: "Twitter",
       path: "https://x.com/kscalelabs",
       icon: <FaXTwitter className="h-5 w-5" />,
-      // description: "Follow us on Twitter for updates on what we're building.",
+      description: "",
     },
     {
       name: "GitHub",
       path: "https://github.com/kscalelabs",
       icon: <FaGithub className="h-5 w-5" />,
-      // description: "Check out our open-source projects on GitHub.",
+      description: "",
     },
     {
       name: "Docs",
       path: "https://docs.kscale.dev/",
       icon: <FaRegFileLines className="h-5 w-5" />,
+      description: "",
     },
     {
       name: "Research",
       path: "/research",
       icon: <FaWpexplorer className="h-5 w-5" />,
+      description: "",
     },
   ];
 

--- a/frontend/src/components/nav/Navbar.tsx
+++ b/frontend/src/components/nav/Navbar.tsx
@@ -33,8 +33,7 @@ const Navbar = () => {
       name: "Discord",
       path: "https://discord.gg/kscale",
       icon: <FaDiscord className="h-5 w-5" />,
-      description:
-        "",
+      description: "",
     },
     {
       name: "Twitter",

--- a/frontend/src/components/nav/Navbar.tsx
+++ b/frontend/src/components/nav/Navbar.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { FaBars, FaDiscord, FaGithub } from "react-icons/fa";
-import { FaXTwitter } from "react-icons/fa6";
+import { FaRegFileLines, FaWpexplorer, FaXTwitter } from "react-icons/fa6";
 import { Link, useLocation } from "react-router-dom";
 
 import Logo from "@/components/Logo";
@@ -26,8 +26,6 @@ const Navbar = () => {
     { name: "Buy", path: "/buy", isExternal: false },
     { name: "Browse", path: "/browse", isExternal: false },
     { name: "Downloads", path: "/downloads", isExternal: false },
-    { name: "Docs", path: "https://docs.kscale.dev/", isExternal: true },
-    { name: "Research", path: "/research", isExternal: false },
   ];
 
   const communityItems = [
@@ -35,20 +33,30 @@ const Navbar = () => {
       name: "Discord",
       path: "https://discord.gg/kscale",
       icon: <FaDiscord className="h-5 w-5" />,
-      description:
-        "Connect with other robot developers, researchers, and enthusiasts.",
+      // description:
+      //   "Connect with other robot developers, researchers, and enthusiasts.",
     },
     {
       name: "Twitter",
       path: "https://x.com/kscalelabs",
       icon: <FaXTwitter className="h-5 w-5" />,
-      description: "Follow us on Twitter for updates on what we're building.",
+      // description: "Follow us on Twitter for updates on what we're building.",
     },
     {
       name: "GitHub",
       path: "https://github.com/kscalelabs",
       icon: <FaGithub className="h-5 w-5" />,
-      description: "Check out our open-source projects on GitHub.",
+      // description: "Check out our open-source projects on GitHub.",
+    },
+    {
+      name: "Docs",
+      path: "https://docs.kscale.dev/",
+      icon: <FaRegFileLines className="h-5 w-5" />,
+    },
+    {
+      name: "Research",
+      path: "/research",
+      icon: <FaWpexplorer className="h-5 w-5" />,
     },
   ];
 

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -66,7 +66,7 @@ const PageHeader: React.FC<PageHeaderProps> = ({ title, subheading }) => {
     });
 
     if (mousePosRef.current) {
-      const radius = 15;
+      const radius = 6;
       for (let dy = -radius; dy <= radius; dy++) {
         for (let dx = -radius; dx <= radius; dx++) {
           if (dx * dx + dy * dy <= radius * radius) {


### PR DESCRIPTION
**What does this PR do?**

1. Move research and docs tabs into the dropdown
2. Get rid of long descriptions for community links
3. Made it so that there's only one ball on the cellular automaton

**What issues does this PR fix or reference?**

_#466_

**If this PR changes the UI, include a screenshot below.**

NavBar
<img width="1920" alt="Screenshot 2024-10-11 at 12 05 33 PM" src="https://github.com/user-attachments/assets/034b162e-eefa-4295-8fc0-80292f5dc3a3">

Community drop down
<img width="1856" alt="Screenshot 2024-10-11 at 12 06 02 PM" src="https://github.com/user-attachments/assets/04e8de36-2ef8-48bb-9c3c-114268d59620">

One ball on the cellular automaton
<img width="1392" alt="Screenshot 2024-10-11 at 12 07 48 PM" src="https://github.com/user-attachments/assets/03f56b8d-e422-4605-9f06-d35df0747dd5">
