### PR TITLE
Custom Listing Slugs and Unique Usernames

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -71,7 +71,6 @@ const App = () => {
                       <Route path="/signup/:id" element={<EmailSignup />} />
 
                       <Route path="/create" element={<Create />} />
-                      <Route path="/item/:id" element={<ListingDetails />} />
                       <Route
                         path="/item/:username/:slug"
                         element={<ListingDetails />}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -72,6 +72,10 @@ const App = () => {
 
                       <Route path="/create" element={<Create />} />
                       <Route path="/item/:id" element={<ListingDetails />} />
+                      <Route
+                        path="/item/:username/:slug"
+                        element={<ListingDetails />}
+                      />
                       <Route path="/keys" element={<APIKeys />} />
                       <Route path="/profile/:id?" element={<Profile />} />
 

--- a/frontend/src/components/listings/MyListingGrid.tsx
+++ b/frontend/src/components/listings/MyListingGrid.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
 import { Link } from "react-router-dom";
 
 import ListingGridCard from "@/components/listings/ListingGridCard";
@@ -8,128 +7,91 @@ import { paths } from "@/gen/api";
 import { useAlertQueue } from "@/hooks/useAlertQueue";
 import { useAuthentication } from "@/hooks/useAuth";
 
-type ListingInfo =
+type ListingInfo = {
+  id: string;
+  username: string;
+  slug: string | null;
+};
+
+type ListingDetails =
   paths["/listings/batch"]["get"]["responses"][200]["content"]["application/json"]["listings"][number];
 
 interface MyListingGridProps {
-  page: number;
-  setPage: (page: number) => void;
+  userId: string;
 }
 
-const MyListingGrid = ({ page, setPage }: MyListingGridProps) => {
-  const auth = useAuthentication();
+const MyListingGrid = ({ userId }: MyListingGridProps) => {
   const { addErrorAlert } = useAlertQueue();
-
-  const [hasMore, setHasMore] = useState<boolean>(false);
-  const [isLoading, setIsLoading] = useState(true);
-  const [listingInfo, setListingInfo] = useState<ListingInfo[] | null>(null);
+  const auth = useAuthentication();
+  const [listingInfos, setListingInfos] = useState<ListingInfo[] | null>(null);
+  const [listingDetails, setListingDetails] = useState<Record<
+    string,
+    ListingDetails
+  > | null>(null);
 
   useEffect(() => {
-    fetchUserListings();
-  }, [page]);
-
-  const fetchUserListings = async () => {
-    setIsLoading(true);
-    setListingInfo(null);
-
-    const { data, error } = await auth.client.GET("/listings/me", {
-      params: {
-        query: {
-          page: page,
+    const fetchListings = async () => {
+      const { data, error } = await auth.client.GET(
+        "/listings/user/{user_id}",
+        {
+          params: { path: { user_id: userId }, query: { page: 1 } },
         },
-      },
-    });
+      );
 
-    if (error) {
-      addErrorAlert(error);
-    } else {
-      setHasMore(data.has_next);
-      fetchListings(data.listing_ids);
-    }
-  };
+      if (error) {
+        addErrorAlert(error);
+        return;
+      }
 
-  const fetchListings = async (ids: string[]) => {
-    if (ids.length === 0) {
-      setListingInfo([]);
-      setIsLoading(false);
-      return;
-    }
+      setListingInfos(data.listings);
 
-    const { data, error } = await auth.client.GET("/listings/batch", {
-      params: {
-        query: {
-          ids: ids,
-        },
-      },
-    });
+      if (data.listings.length > 0) {
+        const { data: batchData, error: batchError } = await auth.client.GET(
+          "/listings/batch",
+          {
+            params: {
+              query: {
+                ids: data.listings.map((info: ListingInfo) => info.id),
+              },
+            },
+          },
+        );
 
-    if (error) {
-      addErrorAlert(error);
-    } else {
-      setListingInfo(data.listings);
-    }
-    setIsLoading(false);
-  };
+        if (batchError) {
+          addErrorAlert(batchError);
+          return;
+        }
 
-  const prevButton = page > 1;
-  const nextButton = hasMore;
+        const detailsMap: Record<string, ListingDetails> = {};
+        batchData.listings.forEach((listing: ListingDetails) => {
+          detailsMap[listing.id] = listing;
+        });
+        setListingDetails(detailsMap);
+      }
+    };
 
-  return (
-    <>
-      {isLoading ? (
-        <div className="flex justify-center items-center h-64">
-          <Spinner />
-        </div>
-      ) : (
-        <>
-          {listingInfo && listingInfo.length > 0 ? (
-            <div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6">
-                {listingInfo.map((listing) => (
-                  <Link to={`/item/${listing.id}`} key={listing.id}>
-                    <ListingGridCard
-                      listingId={listing.id}
-                      listing={listing}
-                      showDescription={true}
-                    />
-                  </Link>
-                ))}
-              </div>
-              <div className="flex justify-between mt-6">
-                <button
-                  className={`px-4 py-2 rounded flex items-center justify-center ${prevButton ? "bg-gray-12 text-white" : "bg-gray-7 text-gray-12 cursor-not-allowed"}`}
-                  onClick={() => {
-                    if (prevButton) {
-                      setPage(page - 1);
-                    }
-                  }}
-                  disabled={!prevButton}
-                >
-                  <FaChevronLeft className="text-xs mr-2" />
-                  <span>Previous</span>
-                </button>
-                <button
-                  className={`px-4 py-2 rounded flex items-center justify-center ${nextButton ? "bg-gray-12 text-white" : "bg-gray-7 text-gray-12 cursor-not-allowed"}`}
-                  onClick={() => {
-                    if (nextButton) {
-                      setPage(page + 1);
-                    }
-                  }}
-                  disabled={!nextButton}
-                >
-                  <span>Next</span>
-                  <FaChevronRight className="text-xs ml-2" />
-                </button>
-              </div>
-            </div>
-          ) : (
-            <p className="flex justify-center items-center h-64">
-              You have not created any listings
-            </p>
-          )}
-        </>
-      )}
-    </>
+    fetchListings();
+  }, [userId]);
+
+  return listingInfos === null ? (
+    <div className="flex justify-center items-center h-64">
+      <Spinner />
+    </div>
+  ) : (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6">
+      {listingInfos.map((info) => (
+        <Link
+          to={`/item/${info.username}/${info.slug || info.id}`}
+          key={info.id}
+        >
+          <ListingGridCard
+            listingId={info.id}
+            listing={listingDetails?.[info.id]}
+            showDescription={true}
+          />
+        </Link>
+      ))}
+    </div>
   );
 };
 

--- a/frontend/src/components/pages/Account.tsx
+++ b/frontend/src/components/pages/Account.tsx
@@ -73,6 +73,22 @@ const Account = () => {
     }
   };
 
+  const handleUpdateUsername = async (newUsername: string) => {
+    try {
+      const { data, error } = await auth.client.PUT("/users/me/username", {
+        body: { new_username: newUsername },
+      });
+      if (error) {
+        addErrorAlert(error);
+      } else {
+        setUser({ ...user, username: data.username } as AccountResponse);
+        addAlert("Username updated successfully!", "success");
+      }
+    } catch {
+      addErrorAlert("Failed to update username");
+    }
+  };
+
   if (auth.isLoading || isLoading) {
     return (
       <div className="flex justify-center items-center pt-8">
@@ -85,6 +101,7 @@ const Account = () => {
     <RenderProfile
       user={user}
       onUpdateProfile={handleUpdateAccount}
+      onUpdateUsername={handleUpdateUsername}
       canEdit={canEdit}
       listingIds={listingIds}
       isAdmin={isAdmin}

--- a/frontend/src/components/pages/Account.tsx
+++ b/frontend/src/components/pages/Account.tsx
@@ -47,7 +47,7 @@ const Account = () => {
       if (error) {
         addErrorAlert(error);
       } else {
-        setListingIds(data.listing_ids);
+        setListingIds(data.listings.map((listing) => listing.id));
       }
     };
 

--- a/frontend/src/components/pages/Browse.tsx
+++ b/frontend/src/components/pages/Browse.tsx
@@ -13,12 +13,15 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { components } from "@/gen/api";
+import { components, paths } from "@/gen/api";
 import { useAlertQueue } from "@/hooks/useAlertQueue";
 import { useAuthentication } from "@/hooks/useAuth";
 import { useDebounce } from "@uidotdev/usehooks";
 
 type SortOption = components["schemas"]["SortOption"];
+
+type ListingInfo =
+  paths["/listings/search"]["get"]["responses"][200]["content"]["application/json"]["listings"][number];
 
 const Browse = () => {
   const auth = useAuthentication();
@@ -39,6 +42,7 @@ const Browse = () => {
   const [searchQuery, setSearchQuery] = useState(query || "");
   const debouncedSearch = useDebounce(searchQuery, 300);
   const [sortOption, setSortOption] = useState<SortOption>("most_upvoted");
+  const [listingInfos, setListingInfos] = useState<ListingInfo[] | null>(null);
 
   useEffect(() => {
     handleSearch();
@@ -46,6 +50,7 @@ const Browse = () => {
 
   const handleSearch = async () => {
     setListingIds(null);
+    setListingInfos(null);
 
     const { data, error } = await auth.client.GET("/listings/search", {
       params: {
@@ -60,8 +65,8 @@ const Browse = () => {
     if (error) {
       addErrorAlert(error);
     } else {
-      setListingIds(data.listing_ids);
       setMoreListings(data.has_next);
+      setListingInfos(data.listings);
     }
   };
 
@@ -161,7 +166,7 @@ const Browse = () => {
         </div>
       </div>
 
-      <ListingGrid listingIds={listingIds} />
+      <ListingGrid listingInfos={listingInfos} />
 
       {listingIds && (
         <div className="flex justify-between mt-2">

--- a/frontend/src/components/pages/Create.tsx
+++ b/frontend/src/components/pages/Create.tsx
@@ -69,9 +69,6 @@ const Create = () => {
       addErrorAlert(error);
     } else {
       addAlert("New listing was created successfully", "success");
-      console.log(responseData);
-      console.log(responseData.username);
-      console.log(responseData.slug);
       navigate(`/item/${responseData.username}/${responseData.slug}`);
     }
   };

--- a/frontend/src/components/pages/Create.tsx
+++ b/frontend/src/components/pages/Create.tsx
@@ -22,6 +22,7 @@ const Create = () => {
 
   const [description, setDescription] = useState<string>("");
   const [slug, setSlug] = useState<string>("");
+  const [previewUrl, setPreviewUrl] = useState<string>("");
 
   const {
     register,
@@ -43,6 +44,12 @@ const Create = () => {
     }
   }, [name, setValue]);
 
+  useEffect(() => {
+    if (auth.currentUser && slug) {
+      setPreviewUrl(`/item/${auth.currentUser.username}/${slug}`);
+    }
+  }, [auth.currentUser, slug]);
+
   // On submit, add the listing to the database and navigate to the
   // newly-created listing.
   const onSubmit = async ({ name, description, slug }: NewListingType) => {
@@ -62,7 +69,10 @@ const Create = () => {
       addErrorAlert(error);
     } else {
       addAlert("New listing was created successfully", "success");
-      navigate(`/item/${responseData.listing_id}`);
+      console.log(responseData);
+      console.log(responseData.username);
+      console.log(responseData.slug);
+      navigate(`/item/${responseData.username}/${responseData.slug}`);
     }
   };
 
@@ -154,6 +164,18 @@ const Create = () => {
                   <ErrorMessage>{errors?.slug?.message}</ErrorMessage>
                 )}
               </div>
+
+              {/* URL Preview */}
+              {previewUrl && (
+                <div>
+                  <label className="block mb-2 text-sm font-medium text-gray-12">
+                    Listing URL Preview
+                  </label>
+                  <div className="p-2 bg-gray-3 rounded-md text-gray-11">
+                    {previewUrl}
+                  </div>
+                </div>
+              )}
 
               {/* Submit */}
               <div className="flex justify-end">

--- a/frontend/src/components/pages/Profile.tsx
+++ b/frontend/src/components/pages/Profile.tsx
@@ -36,7 +36,6 @@ export const RenderProfile = (props: RenderProfileProps) => {
   const [firstName, setFirstName] = useState(user.first_name || "");
   const [lastName, setLastName] = useState(user.last_name || "");
   const [bio, setBio] = useState(user.bio || "");
-  const [myListingsPage, setMyListingsPage] = useState(1);
   const [upvotedPage, setUpvotedPage] = useState(1);
   const [username, setUsername] = useState(user.username || "");
   const [isUsernameAvailable, setIsUsernameAvailable] = useState(true);
@@ -89,8 +88,6 @@ export const RenderProfile = (props: RenderProfileProps) => {
   const handleTabChange = (tab: string) => {
     if (tab === "own") {
       setUpvotedPage(1);
-    } else {
-      setMyListingsPage(1);
     }
   };
 
@@ -318,10 +315,7 @@ export const RenderProfile = (props: RenderProfileProps) => {
                 </TabsTrigger>
               </TabsList>
               <TabsContent value="own">
-                <MyListingGrid
-                  page={myListingsPage}
-                  setPage={setMyListingsPage}
-                />
+                <MyListingGrid userId={user.id} />
               </TabsContent>
               <TabsContent value="upvoted">
                 <UpvotedGrid page={upvotedPage} setPage={setUpvotedPage} />
@@ -385,19 +379,22 @@ const Profile = () => {
     const fetchUserListing = async () => {
       if (id !== undefined) {
         try {
-          const { data, error } = await auth.client.GET("/listings/user/{id}", {
-            params: {
-              path: { id },
-              query: {
-                page: pageNumber,
+          const { data, error } = await auth.client.GET(
+            "/listings/user/{user_id}",
+            {
+              params: {
+                path: { user_id: id },
+                query: {
+                  page: pageNumber,
+                },
               },
             },
-          });
+          );
 
           if (error) {
             addErrorAlert(error);
           } else {
-            setListingIds(data.listing_ids);
+            setListingIds(data.listings.map((listing) => listing.id));
           }
         } catch (err) {
           console.error("Failed to fetch User Listings", err);

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -1389,6 +1389,10 @@ export interface components {
         NewListingResponse: {
             /** Listing Id */
             listing_id: string;
+            /** Username */
+            username: string;
+            /** Slug */
+            slug: string;
         };
         /**
          * Order

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -151,6 +151,60 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/email/signup/create": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Signup Token
+         * @description Creates a signup token and emails it to the user.
+         */
+        post: operations["create_signup_token_email_signup_create_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/email/signup/get/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Signup Token */
+        get: operations["get_signup_token_email_signup_get__id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/email/signup/delete/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Signup Token */
+        delete: operations["delete_signup_token_email_signup_delete__id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/artifacts/url/{artifact_type}/{listing_id}/{name}": {
         parameters: {
             query?: never;
@@ -248,60 +302,6 @@ export interface paths {
         post?: never;
         /** Delete Artifact */
         delete: operations["delete_artifact_artifacts_delete__artifact_id__delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/email/signup/create": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Create Signup Token
-         * @description Creates a signup token and emails it to the user.
-         */
-        post: operations["create_signup_token_email_signup_create_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/email/signup/get/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Signup Token */
-        get: operations["get_signup_token_email_signup_get__id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/email/signup/delete/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete Signup Token */
-        delete: operations["delete_signup_token_email_signup_delete__id__delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -563,6 +563,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/listings/{id}/slug": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update Listing Slug */
+        put: operations["update_listing_slug_listings__id__slug_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/listings/{username}/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Listing By Username And Slug */
+        get: operations["get_listing_by_username_and_slug_listings__username___slug__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/onshape/set/{listing_id}": {
         parameters: {
             query?: never;
@@ -701,6 +735,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/users/me/username": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update Username */
+        put: operations["update_username_users_me_username_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/users/validate-api-key": {
         parameters: {
             query?: never;
@@ -729,6 +780,23 @@ export interface paths {
         put?: never;
         /** Set Moderator */
         post: operations["set_moderator_users_set_moderator_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/check-username/{username}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Check Username Availability */
+        get: operations["check_username_availability_users_check_username__username__get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -1202,6 +1270,8 @@ export interface components {
             updated_at: number;
             /** Name */
             name: string;
+            /** Slug */
+            slug: string;
             /** Child Ids */
             child_ids: string[];
             /** Description */
@@ -1308,10 +1378,12 @@ export interface components {
         NewListingRequest: {
             /** Name */
             name: string;
-            /** Child Ids */
-            child_ids: string[];
             /** Description */
             description: string | null;
+            /** Child Ids */
+            child_ids: string[];
+            /** Slug */
+            slug: string;
         };
         /** NewListingResponse */
         NewListingResponse: {
@@ -1391,6 +1463,8 @@ export interface components {
             id: string;
             /** Email */
             email: string;
+            /** Username */
+            username: string;
             /** Permissions */
             permissions?: ("is_admin" | "is_mod")[] | null;
             /** Created At */
@@ -1498,6 +1572,11 @@ export interface components {
             /** Bio */
             bio?: string | null;
         };
+        /** UpdateUsernameRequest */
+        UpdateUsernameRequest: {
+            /** New Username */
+            new_username: string;
+        };
         /** UploadArtifactResponse */
         UploadArtifactResponse: {
             /** Artifacts */
@@ -1529,6 +1608,8 @@ export interface components {
             id: string;
             /** Email */
             email: string;
+            /** Username */
+            username: string;
             /** Permissions */
             permissions?: ("is_admin" | "is_mod")[] | null;
             /** Created At */
@@ -1783,6 +1864,101 @@ export interface operations {
             };
         };
     };
+    create_signup_token_email_signup_create_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EmailSignUpRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EmailSignUpResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_signup_token_email_signup_get__id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetTokenResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_signup_token_email_signup_delete__id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeleteTokenResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     artifact_url_artifacts_url__artifact_type___listing_id___name__get: {
         parameters: {
             query?: {
@@ -1968,101 +2144,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": boolean;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_signup_token_email_signup_create_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["EmailSignUpRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["EmailSignUpResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_signup_token_email_signup_get__id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GetTokenResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_signup_token_email_signup_delete__id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DeleteTokenResponse"];
                 };
             };
             /** @description Validation Error */
@@ -2576,6 +2657,71 @@ export interface operations {
             };
         };
     };
+    update_listing_slug_listings__id__slug_put: {
+        parameters: {
+            query: {
+                new_slug: string;
+            };
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": boolean;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_listing_by_username_and_slug_listings__username___slug__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                username: string;
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetListingResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     set_onshape_document_onshape_set__listing_id__post: {
         parameters: {
             query?: never;
@@ -2870,6 +3016,39 @@ export interface operations {
             };
         };
     };
+    update_username_users_me_username_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateUsernameRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     validate_api_key_endpoint_users_validate_api_key_get: {
         parameters: {
             query?: never;
@@ -2910,6 +3089,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UserPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    check_username_availability_users_check_username__username__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                username: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: boolean;
+                    };
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -409,15 +409,15 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/listings/user/{id}": {
+    "/listings/user/{user_id}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** List User Listings */
-        get: operations["list_user_listings_listings_user__id__get"];
+        /** Get User Listings */
+        get: operations["get_user_listings_listings_user__user_id__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -433,8 +433,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List My Listings */
-        get: operations["list_my_listings_listings_me_get"];
+        /** Get My Listings */
+        get: operations["get_my_listings_listings_me_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1244,8 +1244,8 @@ export interface components {
         };
         /** ListListingsResponse */
         ListListingsResponse: {
-            /** Listing Ids */
-            listing_ids: string[];
+            /** Listings */
+            listings: components["schemas"]["ListingInfo"][];
             /**
              * Has Next
              * @default false
@@ -1270,8 +1270,10 @@ export interface components {
             updated_at: number;
             /** Name */
             name: string;
+            /** Username */
+            username?: string | null;
             /** Slug */
-            slug: string;
+            slug?: string | null;
             /** Child Ids */
             child_ids: string[];
             /** Description */
@@ -1298,6 +1300,15 @@ export interface components {
              * @default 0
              */
             score: number;
+        };
+        /** ListingInfo */
+        ListingInfo: {
+            /** Id */
+            id: string;
+            /** Username */
+            username: string;
+            /** Slug */
+            slug: string | null;
         };
         /** ListingInfoResponse */
         ListingInfoResponse: {
@@ -1585,13 +1596,6 @@ export interface components {
         UploadArtifactResponse: {
             /** Artifacts */
             artifacts: components["schemas"]["SingleArtifactResponse"][];
-        };
-        /** UpvotedListingsResponse */
-        UpvotedListingsResponse: {
-            /** Upvoted Listing Ids */
-            upvoted_listing_ids: string[];
-            /** Has More */
-            has_more: boolean;
         };
         /** UserInfoResponseItem */
         UserInfoResponseItem: {
@@ -2333,17 +2337,15 @@ export interface operations {
             };
         };
     };
-    list_user_listings_listings_user__id__get: {
+    get_user_listings_listings_user__user_id__get: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Page number for pagination */
-                page: number;
-                /** @description Search query string */
-                search_query?: string;
+                page?: number;
             };
             header?: never;
             path: {
-                id: string;
+                user_id: string;
             };
             cookie?: never;
         };
@@ -2369,13 +2371,11 @@ export interface operations {
             };
         };
     };
-    list_my_listings_listings_me_get: {
+    get_my_listings_listings_me_get: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Page number for pagination */
-                page: number;
-                /** @description Search query string */
-                search_query?: string;
+                page?: number;
             };
             header?: never;
             path?: never;
@@ -2520,7 +2520,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["UpvotedListingsResponse"];
+                    "application/json": components["schemas"]["ListListingsResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/hooks/useDebounce.tsx
+++ b/frontend/src/hooks/useDebounce.tsx
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/frontend/src/hooks/useGetUserListing.tsx
+++ b/frontend/src/hooks/useGetUserListing.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useState } from "react";
 
+import { paths } from "@/gen/api";
 import { useAlertQueue } from "@/hooks/useAlertQueue";
 import { useAuthentication } from "@/hooks/useAuth";
+
+type ListingInfo =
+  paths["/listings/me"]["get"]["responses"][200]["content"]["application/json"]["listings"][number];
 
 const useGetUserListing = ({
   pageNumber,
@@ -12,7 +16,9 @@ const useGetUserListing = ({
 }) => {
   const auth = useAuthentication();
   const { addErrorAlert } = useAlertQueue();
-  const [listingIds, setListingIds] = useState<string[] | null>(null);
+  const [listingInfos, setListingInfos] = useState<ListingInfo[] | null>(null);
+  const [hasNext, setHasNext] = useState<boolean>(false);
+
   useEffect(() => {
     async function fetchData() {
       const { data, error } = await auth.client.GET("/listings/me", {
@@ -26,13 +32,16 @@ const useGetUserListing = ({
       if (error) {
         addErrorAlert(error);
       } else {
-        setListingIds(data.listing_ids);
+        setListingInfos(data.listings);
+        setHasNext(data.has_next);
       }
     }
     fetchData();
-  }, []);
+  }, [pageNumber, searchQuery, auth.client, addErrorAlert]);
+
   return {
-    listingIds,
+    listingInfos,
+    hasNext,
   };
 };
 

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -73,6 +73,13 @@ export const NewListingSchema = z.object({
   description: z
     .string({ required_error: "Description is required." })
     .min(6, { message: "Description must be at least 6 characters long." }),
+  slug: z
+    .string({ required_error: "Slug is required." })
+    .min(1, { message: "Slug is required." })
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
+      message:
+        "Slug must contain only lowercase letters, numbers, and hyphens.",
+    }),
 });
 
 export type NewListingType = z.infer<typeof NewListingSchema>;

--- a/frontend/src/lib/utils/formatString.ts
+++ b/frontend/src/lib/utils/formatString.ts
@@ -10,3 +10,10 @@ export const normalizeStatus = (status: string): string => {
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(" ");
 };
+
+export const slugify = (string: string): string => {
+  return string
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+};

--- a/store/app/crud/listings.py
+++ b/store/app/crud/listings.py
@@ -40,9 +40,20 @@ class ListingsCrud(ArtifactsCrud, BaseCrud):
     ) -> tuple[list[Listing], bool]:
         sort_key = self._get_sort_key(sort_by)
         try:
-            result = await self._list(Listing, page, sort_key, search_query)
-            logger.info(f"Retrieved {len(result[0])} listings")
-            return result
+            listings, has_next = await self._list(Listing, page, sort_key, search_query)
+
+            # Fetch usernames for listings that don't have them
+            listings_without_username = [listing for listing in listings if listing.username is None]
+            if listings_without_username:
+                user_ids = [listing.user_id for listing in listings_without_username]
+                users = await self._get_item_batch(user_ids, User)
+                user_map = {user.id: user.username for user in users if user is not None}
+
+                for listing in listings_without_username:
+                    listing.username = user_map.get(listing.user_id)
+
+            logger.info(f"Retrieved {len(listings)} listings")
+            return listings, has_next
         except Exception as e:
             logger.error(f"Error in get_listings: {str(e)}")
             raise
@@ -98,19 +109,35 @@ class ListingsCrud(ArtifactsCrud, BaseCrud):
 
         return paginated_items, len(sorted_items) > end
 
-    async def get_user_listings(self, user_id: str, page: int, search_query: str) -> tuple[list[Listing], bool]:
-        return await self._list_me(Listing, user_id, page, lambda x: 0, search_query)
+    async def get_user_listings(
+        self,
+        user_id: str,
+        page: int,
+        sort_by: SortOption = SortOption.NEWEST,
+    ) -> tuple[list[Listing], bool]:
+        sort_key = self._get_sort_key(sort_by)
+        try:
+            listings, has_next = await self._list_me(Listing, user_id, page, sort_key)
+
+            # Ensure username is set for all listings
+            for listing in listings:
+                if listing.username is None:
+                    user = await self._get_item(user_id, User)
+                    listing.username = user.username if user else "Unknown"
+
+            logger.info(f"Retrieved {len(listings)} listings for user {user_id}")
+            return listings, has_next
+        except Exception as e:
+            logger.error(f"Error in get_user_listings: {str(e)}")
+            raise
 
     async def dump_listings(self) -> list[Listing]:
         return await self._list_items(Listing)
 
     async def add_listing(self, listing: Listing) -> None:
-        try:
-            await asyncio.gather(
-                *(self._get_item(child_id, Listing, throw_if_missing=True) for child_id in listing.child_ids),
-            )
-        except ItemNotFoundError:
-            raise ValueError("One or more artifact or child IDs is invalid")
+        if listing.username is None:
+            user = await self._get_item(listing.user_id, User, throw_if_missing=True)
+            listing.username = user.username
         await self._add_item(listing)
 
     async def _delete_listing_artifacts(self, listing: Listing) -> None:
@@ -288,7 +315,7 @@ class ListingsCrud(ArtifactsCrud, BaseCrud):
         votes = await self._get_items_from_secondary_index("user_id", user_id, ListingVote)
         return [vote for vote in votes if vote.listing_id in listing_ids]
 
-    async def get_upvoted_listings(self, user_id: str, page: int = 1) -> tuple[list[Listing], bool]:
+    async def get_upvoted_listings(self, user_id: str, page: int = 1) -> tuple[list[dict], bool]:
         user_votes = await self._get_items_from_secondary_index(
             secondary_index_name="user_id", secondary_index_value=user_id, item_class=ListingVote
         )
@@ -310,7 +337,13 @@ class ListingsCrud(ArtifactsCrud, BaseCrud):
 
         has_more = len(upvoted_listing_ids) > end
 
-        return paginated_listings, has_more
+        # Convert Listing objects to dictionaries with username and slug
+        listing_dicts = []
+        for listing in paginated_listings:
+            user = await self._get_item(listing.user_id, User)
+            listing_dicts.append({"id": listing.id, "username": user.username if user else None, "slug": listing.slug})
+
+        return listing_dicts, has_more
 
     async def set_slug(self, listing_id: str, new_slug: str) -> Listing:
         listing = await self.get_listing(listing_id)
@@ -330,3 +363,8 @@ class ListingsCrud(ArtifactsCrud, BaseCrud):
             return None
         listings = await self._get_items_from_secondary_index("user_id", user.id, Listing)
         return next((listing for listing in listings if listing.slug == slug), None)
+
+    async def update_username_for_user_listings(self, user_id: str, new_username: str) -> None:
+        listings = await self._get_items_from_secondary_index("user_id", user_id, Listing)
+        update_tasks = [self._update_item(listing.id, Listing, {"username": new_username}) for listing in listings]
+        await asyncio.gather(*update_tasks)

--- a/store/app/crud/users.py
+++ b/store/app/crud/users.py
@@ -11,6 +11,7 @@ from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 
 from store.app.crud.base import TABLE_NAME, BaseCrud
+from store.app.crud.listings import ListingsCrud
 from store.app.model import (
     APIKey,
     APIKeyPermissionSet,
@@ -239,6 +240,12 @@ class UserCrud(BaseCrud):
         user = await self.get_user(user_id, throw_if_missing=True)
         user.set_username(new_username)
         await self._update_item(user_id, User, {"username": new_username, "updated_at": user.updated_at})
+
+        # Update username in all listings
+        listings_crud = ListingsCrud()
+        async with listings_crud:
+            await listings_crud.update_username_for_user_listings(user_id, new_username)
+
         return user
 
     async def is_username_taken(self, username: str) -> bool:

--- a/store/app/model.py
+++ b/store/app/model.py
@@ -402,7 +402,8 @@ class Listing(StoreBaseModel):
     created_at: int
     updated_at: int
     name: str
-    slug: str
+    username: str | None = None
+    slug: str | None = None
     child_ids: list[str]
     description: str | None = None
     onshape_url: str | None = None
@@ -416,6 +417,7 @@ class Listing(StoreBaseModel):
         cls,
         user_id: str,
         name: str,
+        username: str,
         slug: str,
         child_ids: list[str],
         description: str | None = None,
@@ -427,6 +429,7 @@ class Listing(StoreBaseModel):
             created_at=int(time.time()),
             updated_at=int(time.time()),
             name=name,
+            username=username,
             slug=slug,
             child_ids=child_ids,
             description=description,

--- a/store/app/model.py
+++ b/store/app/model.py
@@ -34,12 +34,13 @@ UserPermission = Literal["is_admin", "is_mod"]
 class User(StoreBaseModel):
     """Defines the user model for the API.
 
-    Users are defined by their id and email (both unique).
+    Users are defined by their id, email, and username (all unique).
     Hashed password is set if user signs up with email and password, and is
     left empty if the user signed up with Google or Github OAuth.
     """
 
     email: str
+    username: str
     hashed_password: str | None = None
     permissions: set[UserPermission] | None = None
     created_at: int
@@ -55,6 +56,7 @@ class User(StoreBaseModel):
     def create(
         cls,
         email: str,
+        username: str,
         password: str | None = None,
         github_id: str | None = None,
         google_id: str | None = None,
@@ -68,6 +70,7 @@ class User(StoreBaseModel):
         return cls(
             id=new_uuid(),
             email=email,
+            username=username,
             hashed_password=hashed_pw,
             created_at=now,
             updated_at=now,
@@ -85,6 +88,10 @@ class User(StoreBaseModel):
     def verify_email(self) -> None:
         self.email_verified_at = int(time.time())
 
+    def set_username(self, new_username: str) -> None:
+        self.username = new_username
+        self.update_timestamp()
+
 
 class UserPublic(BaseModel):
     """Defines public user model for frontend.
@@ -95,6 +102,7 @@ class UserPublic(BaseModel):
 
     id: str
     email: str
+    username: str
     permissions: set[UserPermission] | None = None
     created_at: int
     updated_at: int | None = None
@@ -394,6 +402,7 @@ class Listing(StoreBaseModel):
     created_at: int
     updated_at: int
     name: str
+    slug: str
     child_ids: list[str]
     description: str | None = None
     onshape_url: str | None = None
@@ -407,6 +416,7 @@ class Listing(StoreBaseModel):
         cls,
         user_id: str,
         name: str,
+        slug: str,
         child_ids: list[str],
         description: str | None = None,
         onshape_url: str | None = None,
@@ -417,6 +427,7 @@ class Listing(StoreBaseModel):
             created_at=int(time.time()),
             updated_at=int(time.time()),
             name=name,
+            slug=slug,
             child_ids=child_ids,
             description=description,
             onshape_url=onshape_url,
@@ -425,6 +436,10 @@ class Listing(StoreBaseModel):
             downvotes=0,
             score=0,
         )
+
+    def set_slug(self, new_slug: str) -> None:
+        self.slug = new_slug
+        self.updated_at = int(time.time())
 
 
 class ListingTag(StoreBaseModel):

--- a/store/app/routers/listings.py
+++ b/store/app/routers/listings.py
@@ -246,7 +246,11 @@ async def get_upvoted_listings(
     page: int = Query(1, description="Page number for pagination"),
 ) -> ListListingsResponse:
     listings, has_next = await crud.get_upvoted_listings(user.id, page)
-    return ListListingsResponse(listings=listings, has_next=has_next)
+    listing_infos = [
+        ListingInfo(id=listing["id"], username=listing["username"] or "Unknown", slug=listing["slug"])
+        for listing in listings
+    ]
+    return ListListingsResponse(listings=listing_infos, has_next=has_next)
 
 
 class GetListingResponse(BaseModel):

--- a/store/app/routers/listings.py
+++ b/store/app/routers/listings.py
@@ -140,6 +140,8 @@ class NewListingRequest(BaseModel):
 
 class NewListingResponse(BaseModel):
     listing_id: str
+    username: str
+    slug: str
 
 
 @listings_router.post("/add", response_model=NewListingResponse)
@@ -157,7 +159,7 @@ async def add_listing(
         user_id=user.id,
     )
     await crud.add_listing(listing)
-    return NewListingResponse(listing_id=listing.id)
+    return NewListingResponse(listing_id=listing.id, username=user.username, slug=data.slug)
 
 
 @listings_router.delete("/delete/{listing_id}", response_model=bool)
@@ -371,7 +373,7 @@ async def get_listing_by_username_and_slug(
         name=listing.name,
         description=listing.description,
         child_ids=listing.child_ids,
-        tags=listing_tags,  # This is now correct as listing_tags is already a list[str]
+        tags=listing_tags,
         onshape_url=listing.onshape_url,
         can_edit=user is not None and await can_write_listing(user, listing),
         created_at=listing.created_at,

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -17,11 +17,7 @@ def test_user_auth_functions(test_client: TestClient, tmpdir: Path) -> None:
     # Create a listing.
     response = test_client.post(
         "/listings/add",
-        json={
-            "name": "test listing",
-            "description": "test description",
-            "child_ids": [],
-        },
+        json={"name": "test listing", "description": "test description", "child_ids": [], "slug": "test-listing"},
         headers=auth_headers,
     )
     assert response.status_code == status.HTTP_200_OK, response.json()

--- a/tests/test_listings.py
+++ b/tests/test_listings.py
@@ -79,7 +79,7 @@ def test_listings(test_client: TestClient, tmpdir: Path) -> None:
 
     response = test_client.get(f"/listings/user/{id}", headers=auth_headers, params={"page": 1})
     assert response.status_code == status.HTTP_200_OK, response.json()
-    items = response.json()["listing_ids"]
+    items = response.json()["listings"]
     assert (num_listings := len(items)) >= 1
 
     # Checks my own listings.
@@ -90,7 +90,7 @@ def test_listings(test_client: TestClient, tmpdir: Path) -> None:
     )
     assert response.status_code == status.HTTP_200_OK, response.json()
     data = response.json()
-    items, has_next = data["listing_ids"], data["has_next"]
+    items, has_next = data["listings"], data["has_next"]
     assert (num_listings := len(items)) >= 1
 
     # Uploads a zipfile.
@@ -123,13 +123,13 @@ def test_listings(test_client: TestClient, tmpdir: Path) -> None:
     )
     assert response.status_code == status.HTTP_200_OK, response.json()
     data = response.json()
-    items, has_next = data["listing_ids"], data["has_next"]
+    items, has_next = data["listings"], data["has_next"]
     assert len(items) == num_listings
-    listing_ids = data["listing_ids"]
-    assert listing_id in listing_ids
+    listings = data["listings"]
+    assert listing_id in [listing["id"] for listing in listings]
 
     # Gets the listing by ID.
-    listing_id = listing_ids[0]
+    listing_id = listings[0]["id"]
     response = test_client.get(f"/listings/{listing_id}", headers=auth_headers)
     assert response.status_code == status.HTTP_200_OK, response.json()
 
@@ -208,7 +208,7 @@ def test_listings(test_client: TestClient, tmpdir: Path) -> None:
     )
     assert response.status_code == status.HTTP_200_OK, response.json()
     data = response.json()
-    items, has_next = data["listing_ids"], data["has_next"]
+    items, has_next = data["listings"], data["has_next"]
     assert len(items) == num_listings - 1
     assert not has_next
 

--- a/tests/test_listings.py
+++ b/tests/test_listings.py
@@ -19,11 +19,7 @@ def test_listings(test_client: TestClient, tmpdir: Path) -> None:
     # Create a listing.
     response = test_client.post(
         "/listings/add",
-        json={
-            "name": "test listing",
-            "description": "test description",
-            "child_ids": [],
-        },
+        json={"name": "test listing", "description": "test description", "child_ids": [], "slug": "test-listing"},
         headers=auth_headers,
     )
     assert response.status_code == status.HTTP_200_OK, response.json()


### PR DESCRIPTION
**What does this PR do?**
- [x] 1. Users have unique usernames
- [x]  2. Users can edit their usernames (includes UI showing if username is available or taken)
- [x] 3. Listings have custom slugs that can be set on creation/edited. `/item/winston/stompy-pro` {username}/{slug}
- [x] 4. When users edit their username it also adjusts the listing slug i.e. i change my username from "winston" to "winstonhsiao" listing slug is now `item/winstonhsiao/stompy-pro **(warning breaks old/existing links)**
- [ ] 5. Allow users to edit listing slug, and show preview of new url after change
- [ ] 6. Rate limit username changes (only once a month)? also warn users that editing username will change existing links
- [ ] 7. Make sure this PR is ready for prod (username and slug are new required fields on User and Listing models, need to do DB migration)


https://github.com/user-attachments/assets/98214bd6-dbeb-4b3b-b00c-95675ddab59e

