### PR TITLE
Update OrderSuccess – route to terminal instead of orders

### DIFF
--- a/frontend/src/components/pages/OrderSuccess.tsx
+++ b/frontend/src/components/pages/OrderSuccess.tsx
@@ -38,7 +38,7 @@ const OrderSuccess: React.FC = () => {
               <a href="/">Return to Home</a>
             </Button>
             <Button asChild variant="primary">
-              <a href="/orders">View Your Orders</a>
+              <a href="/terminal">View Your Orders</a>
             </Button>
           </div>
         </CardContent>


### PR DESCRIPTION
**What does this PR do?**

 after successful order, route to `/terminal` instead of `/orders`

