### PR TITLE
Resoled issue where notifications would show up behind price bar

### DIFF
--- a/frontend/src/components/products/ProductPage.tsx
+++ b/frontend/src/components/products/ProductPage.tsx
@@ -1065,7 +1065,7 @@ const ProductPage: React.FC<ProductPageProps> = ({
           </div>
 
           {shouldShowCheckout && isFixed && (
-            <div className="fixed bottom-0 left-0 right-0 bg-white shadow-md p-4 transition-all duration-300 ease-in-out z-10">
+            <div className="fixed bottom-0 left-0 right-0 bg-white shadow-md p-4 transition-all duration-300 ease-in-out z-[5]">
               <div className="max-w-7xl mx-auto flex justify-between items-center px-6">
                 <p className="text-2xl font-semibold">
                   {formatPrice(currentPrice)}

--- a/frontend/src/hooks/useAlertQueue.tsx
+++ b/frontend/src/hooks/useAlertQueue.tsx
@@ -123,7 +123,7 @@ export const AlertQueue = (props: AlertQueueProps) => {
     <>
       {children}
       {/* Render the alerts coming up from the bottom-left corner. */}
-      <div className="fixed bottom-0 left-0 p-4 space-y-4">
+      <div className="fixed bottom-0 left-0 p-4 space-y-4 z-[9999]">
         {Array.from(alerts).map(([alertId, [alert, kind]]) => {
           return (
             <Toast


### PR DESCRIPTION
**What does this PR do?**

Ensure notifications display above price bar on build listings

<img width="1728" alt="Screenshot 2024-11-03 at 6 27 16 PM" src="https://github.com/user-attachments/assets/5ba77b10-0a76-4761-8c8d-eb8f307ed35c">
