### PR TITLE
Listings for sale improvements

### DIFF
--- a/frontend/src/components/listing/ListingPayment.tsx
+++ b/frontend/src/components/listing/ListingPayment.tsx
@@ -60,6 +60,8 @@ const ListingPayment = ({
           listingId={listingId}
           stripeProductId={stripeProductId}
           label="Purchase Now"
+          inventoryType={inventoryType}
+          inventoryQuantity={inventoryQuantity}
         />
       </div>
     </div>

--- a/frontend/src/components/listing/ListingRenderer.tsx
+++ b/frontend/src/components/listing/ListingRenderer.tsx
@@ -74,6 +74,14 @@ const ListingRenderer = ({ listing }: { listing: ListingResponse }) => {
             createdAt={createdAt}
           />
 
+          <hr className="border-gray-2 my-4" />
+
+          <ListingDescription
+            listingId={listingId}
+            description={description}
+            edit={canEdit}
+          />
+
           {/* Add payment section if price exists */}
           {isForSale && (
             <>
@@ -92,14 +100,6 @@ const ListingRenderer = ({ listing }: { listing: ListingResponse }) => {
               />
             </>
           )}
-
-          <hr className="border-gray-2 my-4" />
-
-          <ListingDescription
-            listingId={listingId}
-            description={description}
-            edit={canEdit}
-          />
 
           <hr className="border-gray-200 my-4" />
 

--- a/frontend/src/components/listings/ListingGridCard.tsx
+++ b/frontend/src/components/listings/ListingGridCard.tsx
@@ -1,4 +1,5 @@
 import { paths } from "@/gen/api";
+import { formatPrice } from "@/lib/utils/formatNumber";
 
 import { RenderDescription } from "../listing/ListingDescription";
 
@@ -57,6 +58,20 @@ const ListingGridCard = ({
             <RenderDescription
               description={getFirstLine(listing.description) || ""}
             />
+          </div>
+        )}
+        {listing?.price_amount && (
+          <div className="mt-2 text-sm text-gray-300">
+            {formatPrice(listing.price_amount)}
+            {listing.inventory_type === "finite" &&
+              listing.inventory_quantity !== null && (
+                <span className="ml-2 text-gray-400">
+                  ({listing.inventory_quantity} available)
+                </span>
+              )}
+            {listing.inventory_type === "preorder" && (
+              <span className="ml-2 text-gray-400">(Pre-order)</span>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/components/nav/Navbar.tsx
+++ b/frontend/src/components/nav/Navbar.tsx
@@ -123,7 +123,7 @@ const Navbar = () => {
                     variant="ghost"
                     className="px-3 py-2 text-gray-1"
                   >
-                    <Link to={ROUTES.LOGIN.path}>Sign In</Link>
+                    <Link to={ROUTES.LOGIN.path}>Log In</Link>
                   </Button>
                   <Button
                     asChild

--- a/frontend/src/components/orders/OrderCard.tsx
+++ b/frontend/src/components/orders/OrderCard.tsx
@@ -80,7 +80,7 @@ const OrderCard: React.FC<{ orderWithProduct: OrderWithProduct }> = ({
   return (
     <div className="bg-gray-1 shadow-md rounded-lg p-4 md:p-6 w-full">
       <h2 className="text-gray-12 font-bold text-2xl mb-1">{product.name}</h2>
-      <p className="text-gray-11 mb-2 sm:text-lg">
+      <p className="text-gray-11 mb-1 sm:text-lg">
         Status:{" "}
         <span className={`font-semibold ${getTextColor(order.status)}`}>
           {normalizeStatus(order.status)}
@@ -199,8 +199,8 @@ const OrderCard: React.FC<{ orderWithProduct: OrderWithProduct }> = ({
         </p>
       )}
 
-      <div className="mt-4 text-sm bg-gray-3 p-3 rounded-md text-gray-12">
-        <h3 className="font-semibold text-lg">Shipping Address</h3>
+      <div className="mt-4 text-xs bg-gray-3 p-3 rounded-md text-gray-12">
+        <h3 className="font-semibold">Shipping Address</h3>
         <p>{order.shipping_name}</p>
         <p>{order.shipping_address_line1}</p>
         {order.shipping_address_line2 && <p>{order.shipping_address_line2}</p>}

--- a/frontend/src/components/pages/CreateSell.tsx
+++ b/frontend/src/components/pages/CreateSell.tsx
@@ -142,7 +142,7 @@ const CreateSell = () => {
 
   useEffect(() => {
     if (auth.currentUser && slug) {
-      setPreviewUrl(`/item/${auth.currentUser.username}/${slug}`);
+      setPreviewUrl(`/bot/${auth.currentUser.username}/${slug}`);
     }
   }, [auth.currentUser, slug]);
 
@@ -309,6 +309,35 @@ const CreateSell = () => {
     return true;
   };
 
+  const handleInventoryTypeChange = (
+    e: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    const newType = e.target.value as typeof inventoryType;
+    setInventoryType(newType);
+    setValue("inventory_type", newType);
+
+    // Reset related fields based on inventory type
+    if (newType === "infinite") {
+      setValue("inventory_quantity", null);
+      setValue("preorder_release_date", null);
+    } else if (newType === "preorder") {
+      setValue("inventory_quantity", null);
+      setIsReservation(false);
+      setValue("is_reservation", false);
+      setValue("reservation_deposit_amount", null);
+    } else if (newType === "finite") {
+      setValue("preorder_release_date", null);
+    }
+
+    // Trigger validation
+    trigger([
+      "inventory_quantity",
+      "preorder_release_date",
+      "is_reservation",
+      "reservation_deposit_amount",
+    ]);
+  };
+
   return (
     <RequireAuthentication>
       <Container className="max-w-xl">
@@ -453,15 +482,8 @@ const CreateSell = () => {
                     <select
                       className="w-full p-2 rounded-md border border-gray-7 bg-gray-3 text-gray-12"
                       {...register("inventory_type")}
-                      onChange={(e) => {
-                        setInventoryType(
-                          e.target.value as typeof inventoryType,
-                        );
-                        setValue(
-                          "inventory_type",
-                          e.target.value as typeof inventoryType,
-                        );
-                      }}
+                      onChange={handleInventoryTypeChange}
+                      value={inventoryType}
                     >
                       <option value="infinite">Unlimited</option>
                       <option value="finite">Limited Quantity</option>

--- a/frontend/src/components/pages/CreateSell.tsx
+++ b/frontend/src/components/pages/CreateSell.tsx
@@ -501,6 +501,7 @@ const CreateSell = () => {
                     <Input
                       type="number"
                       min="1"
+                      onWheel={(e) => (e.target as HTMLInputElement).blur()} // prevent changing value when scrolling
                       {...register("inventory_quantity", {
                         valueAsNumber: true,
                         validate: (value) =>

--- a/frontend/src/components/pages/CreateShare.tsx
+++ b/frontend/src/components/pages/CreateShare.tsx
@@ -57,7 +57,7 @@ const CreateShare = () => {
 
   useEffect(() => {
     if (auth.currentUser && slug) {
-      setPreviewUrl(`/item/${auth.currentUser.username}/${slug}`);
+      setPreviewUrl(`/bot/${auth.currentUser.username}/${slug}`);
     }
   }, [auth.currentUser, slug]);
 

--- a/frontend/src/components/pages/Login.tsx
+++ b/frontend/src/components/pages/Login.tsx
@@ -1,10 +1,14 @@
+import { useNavigate } from "react-router-dom";
+
 import AuthBlock from "@/components/auth/AuthBlock";
 
 const Login = () => {
+  const navigate = useNavigate();
+
   return (
     <div className="mx-8">
       <div className="flex justify-center items-center">
-        <AuthBlock title={<span className="text-gray-2">Welcome back!</span>} />
+        <AuthBlock title="Welcome back!" onClosed={() => navigate(-1)} />
       </div>
     </div>
   );

--- a/frontend/src/components/pages/OrderSuccess.tsx
+++ b/frontend/src/components/pages/OrderSuccess.tsx
@@ -20,7 +20,7 @@ const OrderSuccess: React.FC = () => {
 
   return (
     <div className="pt-4 min-h-screen">
-      <Card className="mt-8">
+      <Card className="mt-8 max-w-4xl mx-auto">
         <CardContent className="p-6 flex flex-col items-center">
           <CheckCircle className="w-16 h-16 text-green-500 mb-4" />
           <h2 className="text-2xl font-bold mb-2">Order Successful!</h2>

--- a/frontend/src/components/pages/OrderSuccess.tsx
+++ b/frontend/src/components/pages/OrderSuccess.tsx
@@ -37,7 +37,7 @@ const OrderSuccess: React.FC = () => {
             <Button asChild>
               <a href="/">Return to Home</a>
             </Button>
-            <Button asChild variant="default">
+            <Button asChild variant="outline">
               <a href="/orders">View Your Orders</a>
             </Button>
           </div>

--- a/frontend/src/components/pages/SellerOnboarding.tsx
+++ b/frontend/src/components/pages/SellerOnboarding.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
+import RequireAuthentication from "@/components/auth/RequireAuthentication";
 import Spinner from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
 import { useAlertQueue } from "@/hooks/useAlertQueue";
@@ -40,17 +41,12 @@ export default function SellerOnboarding() {
 
   if (auth.isLoading) {
     return (
-      <div className="container mx-auto px-4 py-8">
+      <div className="mx-auto px-4 py-8">
         <div className="flex justify-center max-w-2xl mx-auto">
           <Spinner />
         </div>
       </div>
     );
-  }
-
-  if (!auth.isAuthenticated) {
-    navigate(ROUTES.LOGIN.path);
-    return null;
   }
 
   const handleCreateAccount = async () => {
@@ -81,73 +77,75 @@ export default function SellerOnboarding() {
   const showStripeConnect = connectedAccountId && stripeConnectInstance;
 
   return (
-    <div className="container mx-auto px-4 py-8 min-h-screen">
-      <div className="max-w-2xl mx-auto">
-        <h1 className="text-3xl font-bold my-8">Start Selling on K-Scale</h1>
+    <RequireAuthentication>
+      <div className="mx-auto min-h-screen">
+        <div className="max-w-3xl mx-auto bg-gray-2 text-gray-12 py-4 px-10 rounded-md">
+          <h1 className="text-3xl font-bold my-8">Start Selling on K-Scale</h1>
 
-        {!connectedAccountId && (
-          <div className="mb-8">
-            <p className="mb-4">
-              Set up your K-Scale connected Stripe account to start selling
-              robots and receiving payments.
-            </p>
+          {!connectedAccountId && (
+            <div className="mb-8">
+              <p className="mb-4">
+                Set up your K-Scale connected Stripe account to start selling
+                robots and receiving payments.
+              </p>
 
-            <Button
-              onClick={handleCreateAccount}
-              disabled={accountCreatePending}
-              variant="outline"
-            >
-              {accountCreatePending
-                ? "Creating account..."
-                : "Start seller onboarding"}
-            </Button>
-          </div>
-        )}
+              <Button
+                onClick={handleCreateAccount}
+                disabled={accountCreatePending}
+                variant="outline"
+              >
+                {accountCreatePending
+                  ? "Creating account..."
+                  : "Start seller onboarding"}
+              </Button>
+            </div>
+          )}
 
-        {showStripeConnect && stripeConnectInstance && (
-          <ConnectComponentsProvider connectInstance={stripeConnectInstance}>
-            <ConnectAccountOnboarding
-              onExit={() => {
-                setOnboardingExited(true);
-                auth.fetchCurrentUser();
-                if (auth.currentUser?.stripe_connect_onboarding_completed) {
-                  navigate(ROUTES.SELL.DASHBOARD.path);
-                }
-              }}
-            />
-          </ConnectComponentsProvider>
-        )}
+          {showStripeConnect && stripeConnectInstance && (
+            <ConnectComponentsProvider connectInstance={stripeConnectInstance}>
+              <ConnectAccountOnboarding
+                onExit={() => {
+                  setOnboardingExited(true);
+                  auth.fetchCurrentUser();
+                  if (auth.currentUser?.stripe_connect_onboarding_completed) {
+                    navigate(ROUTES.SELL.DASHBOARD.path);
+                  }
+                }}
+              />
+            </ConnectComponentsProvider>
+          )}
 
-        {(connectedAccountId || accountCreatePending || onboardingExited) && (
-          <div className="mt-10 p-3 rounded-lg text-sm">
-            {connectedAccountId && (
-              <div className="flex flex-col gap-2">
-                <span className="font-semibold">
-                  Complete the onboarding process to start selling robots.
-                </span>
-                <div className="flex items-center gap-2">
-                  Connected account ID:{" "}
-                  <code className="font-mono bg-gray-11 rounded-md p-1">
-                    {connectedAccountId}
-                  </code>
+          {(connectedAccountId || accountCreatePending || onboardingExited) && (
+            <div className="mt-10 p-3 rounded-lg text-sm">
+              {connectedAccountId && (
+                <div className="flex flex-col gap-2">
+                  <span className="font-semibold">
+                    Complete the onboarding process to start selling robots.
+                  </span>
+                  <div className="flex items-center gap-2">
+                    Connected account ID:{" "}
+                    <code className="font-mono bg-gray-5 rounded-md p-1">
+                      {connectedAccountId}
+                    </code>
+                  </div>
+                  <span className="font-semibold">
+                    This usually takes a few steps/submissions.
+                  </span>
+                  <span className="font-light">
+                    It may take some time for Stripe to process your info
+                    between submissions. Continue through your account page or
+                    refresh this page to check/update your application status.
+                  </span>
                 </div>
-                <span className="font-semibold">
-                  This usually takes a few steps/submissions.
-                </span>
-                <span className="font-light">
-                  It may take some time for Stripe to process your info between
-                  submissions. Continue through your account page or refresh
-                  this page to check/update your application status.
-                </span>
-              </div>
-            )}
-            {accountCreatePending && (
-              <p>Creating a K-Scale Stripe connected account...</p>
-            )}
-            {onboardingExited && <p>Account setup completed</p>}
-          </div>
-        )}
+              )}
+              {accountCreatePending && (
+                <p>Creating a K-Scale Stripe connected account...</p>
+              )}
+              {onboardingExited && <p>Account setup completed</p>}
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+    </RequireAuthentication>
   );
 }

--- a/frontend/src/components/stripe/CheckoutButton.tsx
+++ b/frontend/src/components/stripe/CheckoutButton.tsx
@@ -13,17 +13,33 @@ import { loadStripe } from "@stripe/stripe-js";
 
 const stripePromise = loadStripe(STRIPE_PUBLISHABLE_KEY);
 
-const CheckoutButton: React.FC<{
+interface Props {
   listingId: string;
   stripeProductId: string;
   label?: string;
-}> = ({ listingId, stripeProductId, label = "Order Now" }) => {
+  inventoryType?: "finite" | "infinite" | "preorder";
+  inventoryQuantity?: number;
+}
+
+const CheckoutButton: React.FC<Props> = ({
+  listingId,
+  stripeProductId,
+  label = "Order Now",
+  inventoryType,
+  inventoryQuantity,
+}) => {
   const { addErrorAlert } = useAlertQueue();
   const [isLoading, setIsLoading] = useState(false);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const auth = useAuthentication();
   const navigate = useNavigate();
   const location = useLocation();
+
+  const isOutOfStock =
+    inventoryType === "finite" &&
+    (inventoryQuantity === undefined || inventoryQuantity <= 0);
+
+  const buttonLabel = isOutOfStock ? "Out of Stock" : label;
 
   const handleClick = async () => {
     setIsLoading(true);
@@ -96,12 +112,14 @@ const CheckoutButton: React.FC<{
     <>
       <Button
         onClick={handleClick}
-        disabled={isLoading}
-        className="flex items-center justify-center bg-primary"
+        disabled={isLoading || isOutOfStock}
+        className={`flex items-center justify-center ${
+          isOutOfStock ? "bg-gray-600" : "bg-primary"
+        }`}
         variant="default"
       >
         {isLoading ? <FaSpinner className="animate-spin mr-2" /> : null}
-        {isLoading ? "Starting checkout..." : label}
+        {isLoading ? "Starting checkout..." : buttonLabel}
       </Button>
 
       <Drawer open={isDrawerOpen} setOpen={setIsDrawerOpen}>

--- a/frontend/src/components/terminal/TerminalAllRobots.tsx
+++ b/frontend/src/components/terminal/TerminalAllRobots.tsx
@@ -28,13 +28,16 @@ const TerminalAllRobots = ({ robots, onDeleteRobot }: Props) => {
         </div>
       ) : (
         <div className="flex flex-col gap-4 justify-center items-center bg-gray-12 p-10 rounded-lg max-w-3xl mx-auto border border-white">
-          <p className="text-gray-2 font-medium sm:text-lg">No robots found.</p>
+          <p className="text-gray-2 font-medium sm:text-lg">
+            No robots registered.
+          </p>
+          <p className="text-gray-2">Register a robot to get started.</p>
           <Button
             variant="default"
             onClick={() => navigate(ROUTES.BOTS.BROWSE.path)}
             className="flex items-center bg-gray-12 text-white hover:bg-gray-8 border border-white"
           >
-            <span>Browse Listings</span>
+            <span>Browse Robots</span>
           </Button>
         </div>
       )}

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -897,23 +897,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/stripe/create-payment-intent": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create Payment Intent */
-        post: operations["create_payment_intent_stripe_create_payment_intent_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/stripe/refunds/{order_id}": {
         parameters: {
             query?: never;
@@ -1666,6 +1649,14 @@ export interface components {
             score: number;
             /** User Vote */
             user_vote: boolean | null;
+            /** Price Amount */
+            price_amount: number | null;
+            /** Currency */
+            currency: string | null;
+            /** Inventory Type */
+            inventory_type: ("finite" | "infinite" | "preorder") | null;
+            /** Inventory Quantity */
+            inventory_quantity: number | null;
         };
         /** LoginRequest */
         LoginRequest: {
@@ -1758,8 +1749,8 @@ export interface components {
             currency: string;
             /** Quantity */
             quantity: number;
-            /** Product Id */
-            product_id: string;
+            /** Stripe Product Id */
+            stripe_product_id: string;
             /** Stripe Refund Id */
             stripe_refund_id?: string | null;
             /** Shipping Name */
@@ -3671,26 +3662,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_payment_intent_stripe_create_payment_intent_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": Record<string, never>;
                 };
             };
         };

--- a/store/app/routers/listings.py
+++ b/store/app/routers/listings.py
@@ -260,20 +260,6 @@ async def get_my_listings(
     return ListListingsResponse(listings=listing_infos, has_next=has_next)
 
 
-class NewListingRequest(BaseModel):
-    name: str
-    description: str | None
-    child_ids: list[str]
-    slug: str
-    price_amount: int | None = None  # in cents
-    currency: str = "usd"
-    inventory_type: Literal["finite", "infinite", "preorder"] = "infinite"
-    inventory_quantity: int | None = None
-    preorder_release_date: int | None = None
-    is_reservation: bool = False
-    reservation_deposit_amount: int | None = None
-
-
 class NewListingResponse(BaseModel):
     listing_id: str
     username: str
@@ -338,7 +324,6 @@ async def add_listing(
         )
 
     # Create Stripe product if price is set
-
     if price_amount is not None and user.stripe_connect_account_id:
         try:
             product = stripe.Product.create(

--- a/store/app/routers/listings.py
+++ b/store/app/routers/listings.py
@@ -143,6 +143,10 @@ class ListingInfoResponse(BaseModel):
     views: int
     score: int
     user_vote: bool | None
+    price_amount: int | None
+    currency: str | None
+    inventory_type: Literal["finite", "infinite", "preorder"] | None
+    inventory_quantity: int | None
 
 
 class GetBatchListingsResponse(BaseModel):
@@ -203,6 +207,10 @@ async def get_batch_listing_info(
                     views=listing.views,
                     score=listing.score,
                     user_vote=user_votes.get(listing.id),
+                    price_amount=listing.price_amount,
+                    currency=listing.currency,
+                    inventory_type=listing.inventory_type,
+                    inventory_quantity=listing.inventory_quantity,
                 )
                 listing_responses.append(listing_response)
             except Exception as e:

--- a/store/app/routers/stripe.py
+++ b/store/app/routers/stripe.py
@@ -1,6 +1,5 @@
 """Stripe integration router for handling payments and webhooks."""
 
-import asyncio
 import logging
 from enum import Enum
 from typing import Annotated, Any, Dict, Literal
@@ -145,6 +144,7 @@ async def stripe_webhook(request: Request, crud: Crud = Depends(Crud.get)) -> Di
 
 
 async def handle_checkout_session_completed(session: Dict[str, Any], crud: Crud) -> None:
+    logger.info("Processing checkout session: %s", session["id"])
     try:
         shipping_details = session.get("shipping_details", {})
         shipping_address = shipping_details.get("address", {})
@@ -173,34 +173,19 @@ async def handle_checkout_session_completed(session: Dict[str, Any], crud: Crud)
             "shipping_country": shipping_address.get("country"),
         }
 
-        # Create order and update inventory in parallel
         product_id = session["metadata"].get("product_id")
         if product_id:
             listing = await crud.get_listing_by_stripe_product_id(product_id)
             if listing:
-                # Only decrement inventory for finite listings with successful payments
                 if (
                     listing.inventory_type == "finite"
                     and listing.inventory_quantity is not None
                     and quantity is not None
-                    and session["payment_status"] == "paid"
                 ):
-
                     new_quantity = max(0, listing.inventory_quantity - quantity)
-                    await asyncio.gather(
-                        crud.create_order(order_data),
-                        crud.edit_listing(listing_id=listing.id, inventory_quantity=new_quantity),
-                    )
-                    logger.info("Updated listing inventory from %d to %d", listing.inventory_quantity, new_quantity)
-                    return
-                else:
-                    # Just create the order without updating inventory
-                    await crud.create_order(order_data)
-                    return
+                    await crud.edit_listing(listing_id=listing.id, inventory_quantity=new_quantity)
 
-        # If no inventory update needed, just create the order
         await crud.create_order(order_data)
-        logger.info("New order created: %s", order_data.get("id"))
 
     except Exception as e:
         logger.error("Error processing checkout session: %s", str(e))
@@ -265,7 +250,15 @@ async def create_checkout_session(
             # Get the listing
             listing = await crud.get_listing(request.listing_id)
             if not listing or not listing.price_amount:
+                logger.error(f"Listing not found or has no price: {request.listing_id}")
                 raise HTTPException(status_code=404, detail="Listing not found or has no price")
+
+            # Validate inventory
+            if listing.inventory_type == "finite":
+                if listing.inventory_quantity is None:
+                    raise HTTPException(status_code=400, detail="Invalid inventory configuration")
+                if listing.inventory_quantity <= 0:
+                    raise HTTPException(status_code=400, detail="This item is out of stock")
 
             if not listing.stripe_price_id:
                 raise HTTPException(status_code=400, detail="Listing has no associated Stripe price")
@@ -279,10 +272,10 @@ async def create_checkout_session(
             if seller.id == user.id:
                 raise HTTPException(status_code=400, detail="You cannot purchase your own listing")
 
-            # Calculate maximum quantity and application fee
+            # Calculate maximum quantity
             max_quantity = 10
             if listing.inventory_type == "finite" and listing.inventory_quantity is not None:
-                max_quantity = listing.inventory_quantity
+                max_quantity = min(listing.inventory_quantity, 10)
 
             application_fee = int(listing.price_amount * 0.02)  # 2% fee for our platform
 
@@ -299,9 +292,9 @@ async def create_checkout_session(
                 },
             )
 
-            # Ensure stripe_product_id is not None before adding to metadata
-            metadata = {
+            metadata: dict[str, str] = {
                 "user_email": user.email,
+                "product_id": listing.stripe_product_id or "",
             }
             if listing.stripe_product_id:
                 metadata["stripe_product_id"] = listing.stripe_product_id
@@ -311,15 +304,21 @@ async def create_checkout_session(
                     {
                         "price": platform_price.id,
                         "quantity": 1,
-                        "adjustable_quantity": {
-                            "enabled": True,
-                            "minimum": 1,
-                            "maximum": max_quantity,
-                        },
+                        **(
+                            {
+                                "adjustable_quantity": {
+                                    "enabled": True,
+                                    "minimum": 1,
+                                    "maximum": max_quantity,
+                                }
+                            }
+                            if max_quantity > 1
+                            else {}
+                        ),
                     }
                 ],
                 mode="payment",
-                payment_method_types=["card", "affirm"],
+                payment_method_types=(["card", "affirm"] if listing.price_amount >= 5000 else ["card"]),
                 success_url=f"{settings.site.homepage}/order/success?session_id={{CHECKOUT_SESSION_ID}}",
                 cancel_url=f"{settings.site.homepage}{request.cancel_url}",
                 client_reference_id=user.id,
@@ -332,10 +331,11 @@ async def create_checkout_session(
                     },
                 },
             )
+
             return CreateCheckoutSessionResponse(session_id=checkout_session.id)
 
         except stripe.StripeError as e:
-            logger.error(f"Stripe error: {str(e)}")
+            logger.error(f"Stripe error: {str(e)}", exc_info=True)
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
             logger.error(f"Unexpected error: {str(e)}", exc_info=True)
@@ -383,9 +383,6 @@ async def create_connect_account(
     crud: Annotated[Crud, Depends(Crud.get)],
 ) -> CreateConnectAccountResponse:
     try:
-        logger.info("Starting new account creation for user %s", user.id)
-
-        # Create a Standard Connect account
         account = stripe.Account.create(
             type="standard",
             country="US",
@@ -397,10 +394,8 @@ async def create_connect_account(
             business_type="individual",
         )
 
-        logger.info("Created new Connect account: %s for user: %s", account.id, user.id)
+        logger.info("Created Connect account %s for user %s", account.id, user.id)
 
-        # Update user record with new Connect account ID
-        logger.info("Updating user record with new Connect account ID")
         await crud.update_user(
             user.id,
             {
@@ -411,7 +406,7 @@ async def create_connect_account(
 
         return CreateConnectAccountResponse(account_id=account.id)
     except Exception as e:
-        logger.error("Error creating Connect account: %s", str(e), exc_info=True)
+        logger.error("Error creating Connect account: %s", str(e))
         raise HTTPException(status_code=400, detail=str(e))
 
 


### PR DESCRIPTION
**What does this PR do?**
1. Better default auth flow (require user to be logged in)
2. Improves clarity/UI of robot for sale listings.
3. Decrement listing `inventory_quantity` by quantity after successful order is placed
4. Affirm as payment option ONLY for orders over $50 (otherwise it errors out when trying to start checkout session since Affirm not allowed on less than $50)
5. Quantity 1 fix checkout session (dynamic line item generation)
6. Quantity 0 shows out of stock and does not allow check out session creation
7. Other small misc UI improvements

**What issues does this PR fix or reference?**
Closes #575 

## Lighter backdrop for Stripe Onboarding (better text/bg color contrast ratio)
<img width="1512" alt="Screenshot 2024-11-11 at 3 29 19 PM" src="https://github.com/user-attachments/assets/6ede1469-f603-4335-89ea-93ae9fc643cd">

## Robot listing (sell)
<img width="1512" alt="Screenshot 2024-11-11 at 3 37 02 PM" src="https://github.com/user-attachments/assets/397a644f-9ae1-41a2-acc2-dc18f3ab1e47">

## After placing a successful order via checkout
<img width="1512" alt="Screenshot 2024-11-11 at 6 09 35 PM" src="https://github.com/user-attachments/assets/2077fd28-4f4a-487d-8fa9-105d8be0f659">
