### PR TITLE
Preorder Flow

### DIFF
--- a/frontend/src/components/modals/CancelOrderModal.tsx
+++ b/frontend/src/components/modals/CancelOrderModal.tsx
@@ -42,7 +42,7 @@ const CancelOrderModal: React.FC<CancelOrderModalProps> = ({
   const MAX_REASON_LENGTH = 500;
 
   const [cancellation, setCancellation] = useState({
-    payment_intent_id: order["stripe_payment_intent_id"],
+    payment_intent_id: order["stripe_payment_intent_id"] || "",
     cancel_reason: { reason: "", details: "" },
     amount: order["amount"],
   });
@@ -79,6 +79,12 @@ const CancelOrderModal: React.FC<CancelOrderModalProps> = ({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (!cancellation.payment_intent_id) {
+      addErrorAlert("Invalid payment information");
+      return;
+    }
+
     try {
       const { data, error } = await client.PUT("/stripe/refunds/{order_id}", {
         params: { path: { order_id: order.id } },

--- a/frontend/src/components/pages/CreateSell.tsx
+++ b/frontend/src/components/pages/CreateSell.tsx
@@ -190,7 +190,7 @@ const CreateSell = () => {
       <Container className="max-w-xl">
         <Card>
           <CardHeader>
-            <Header title="List your robot for sale" />
+            <Header title="List your robot" />
           </CardHeader>
           <CardContent>
             <form

--- a/frontend/src/components/stripe/CheckoutButton.tsx
+++ b/frontend/src/components/stripe/CheckoutButton.tsx
@@ -39,7 +39,12 @@ const CheckoutButton: React.FC<Props> = ({
     inventoryType === "finite" &&
     (inventoryQuantity === undefined || inventoryQuantity <= 0);
 
-  const buttonLabel = isOutOfStock ? "Out of Stock" : label;
+  const buttonLabel =
+    inventoryType === "preorder"
+      ? "Pre-order Now"
+      : isOutOfStock
+        ? "Out of Stock"
+        : label;
 
   const handleClick = async () => {
     setIsLoading(true);

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -1033,6 +1033,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/stripe/process-preorder/{order_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Process Preorder */
+        post: operations["process_preorder_stripe_process_preorder__order_id__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/users/me": {
         parameters: {
             query?: never;
@@ -1732,10 +1749,6 @@ export interface components {
             user_id: string;
             /** User Email */
             user_email: string;
-            /** Stripe Checkout Session Id */
-            stripe_checkout_session_id: string;
-            /** Stripe Payment Intent Id */
-            stripe_payment_intent_id: string;
             /** Created At */
             created_at: number;
             /** Updated At */
@@ -1751,8 +1764,16 @@ export interface components {
             currency: string;
             /** Quantity */
             quantity: number;
+            /** Stripe Checkout Session Id */
+            stripe_checkout_session_id: string;
             /** Stripe Product Id */
             stripe_product_id: string;
+            /** Stripe Customer Id */
+            stripe_customer_id?: string | null;
+            /** Stripe Payment Intent Id */
+            stripe_payment_intent_id?: string | null;
+            /** Stripe Payment Method Id */
+            stripe_payment_method_id?: string | null;
             /** Stripe Refund Id */
             stripe_refund_id?: string | null;
             /** Shipping Name */
@@ -3876,6 +3897,37 @@ export interface operations {
                 "application/json": components["schemas"]["Body_create_stripe_product_stripe_create_product_post"];
             };
         };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    process_preorder_stripe_process_preorder__order_id__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                order_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -1403,6 +1403,8 @@ export interface components {
         CreateCheckoutSessionResponse: {
             /** Session Id */
             session_id: string;
+            /** Stripe Connect Account Id */
+            stripe_connect_account_id: string;
         };
         /** CreateConnectAccountResponse */
         CreateConnectAccountResponse: {
@@ -1768,6 +1770,8 @@ export interface components {
             stripe_checkout_session_id: string;
             /** Stripe Product Id */
             stripe_product_id: string;
+            /** Stripe Connect Account Id */
+            stripe_connect_account_id: string;
             /** Stripe Customer Id */
             stripe_customer_id?: string | null;
             /** Stripe Payment Method Id */

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -1770,10 +1770,10 @@ export interface components {
             stripe_product_id: string;
             /** Stripe Customer Id */
             stripe_customer_id?: string | null;
-            /** Stripe Payment Intent Id */
-            stripe_payment_intent_id?: string | null;
             /** Stripe Payment Method Id */
             stripe_payment_method_id?: string | null;
+            /** Stripe Payment Intent Id */
+            stripe_payment_intent_id?: string | null;
             /** Stripe Refund Id */
             stripe_refund_id?: string | null;
             /** Shipping Name */

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -1269,6 +1269,8 @@ export interface components {
             small?: string | null;
             /** Large */
             large: string;
+            /** Expires At */
+            expires_at: number;
         };
         /** AuthResponse */
         AuthResponse: {
@@ -1289,7 +1291,7 @@ export interface components {
             /** Slug */
             slug: string;
             /** Price Amount */
-            price_amount?: number | null;
+            price_amount?: string | null;
             /**
              * Currency
              * @default usd
@@ -1297,21 +1299,21 @@ export interface components {
             currency: string;
             /**
              * Inventory Type
-             * @default infinite
+             * @default finite
              * @enum {string}
              */
-            inventory_type: "finite" | "infinite" | "preorder";
+            inventory_type: "finite" | "preorder";
             /** Inventory Quantity */
-            inventory_quantity?: number | null;
+            inventory_quantity?: string | null;
             /** Preorder Release Date */
-            preorder_release_date?: number | null;
+            preorder_release_date?: string | null;
             /**
              * Is Reservation
              * @default false
              */
             is_reservation: boolean;
             /** Reservation Deposit Amount */
-            reservation_deposit_amount?: number | null;
+            reservation_deposit_amount?: string | null;
             /** Photos */
             photos?: string[];
         };

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -90,9 +90,7 @@ export const ShareListingSchema = BaseListingSchema;
 export const SellListingSchema = BaseListingSchema.extend({
   price_amount: z.number().nullable(),
   currency: z.string().default("usd"),
-  inventory_type: z
-    .enum(["finite", "infinite", "preorder"])
-    .default("infinite"),
+  inventory_type: z.enum(["finite", "preorder"]).default("finite"),
   inventory_quantity: z.number().nullable(),
   preorder_release_date: z.number().nullable(),
   is_reservation: z.boolean().default(false),

--- a/store/app/model.py
+++ b/store/app/model.py
@@ -51,6 +51,7 @@ class User(StoreBaseModel):
     last_name: str | None = None
     name: str | None = None
     bio: str | None = None
+    stripe_customer_id: str | None = None
     stripe_connect_account_id: str | None = None
     stripe_connect_onboarding_completed: bool = False
 
@@ -66,6 +67,7 @@ class User(StoreBaseModel):
         last_name: str | None = None,
         name: str | None = None,
         bio: str | None = None,
+        stripe_customer_id: str | None = None,
         stripe_connect_account_id: str | None = None,
         stripe_connect_onboarding_completed: bool = False,
     ) -> Self:
@@ -84,6 +86,7 @@ class User(StoreBaseModel):
             last_name=last_name,
             name=name,
             bio=bio,
+            stripe_customer_id=stripe_customer_id,
             stripe_connect_account_id=stripe_connect_account_id,
             stripe_connect_onboarding_completed=stripe_connect_onboarding_completed,
         )
@@ -593,9 +596,10 @@ class Order(StoreBaseModel):
     quantity: int
     stripe_checkout_session_id: str
     stripe_product_id: str
+    stripe_connect_account_id: str
     stripe_customer_id: str | None = None
-    stripe_payment_intent_id: str | None = None
     stripe_payment_method_id: str | None = None
+    stripe_payment_intent_id: str | None = None
     stripe_refund_id: str | None = None
     shipping_name: str | None = None
     shipping_address_line1: str | None = None
@@ -615,9 +619,10 @@ class Order(StoreBaseModel):
         quantity: int,
         stripe_checkout_session_id: str,
         stripe_product_id: str,
+        stripe_connect_account_id: str,
         stripe_customer_id: str | None = None,
-        stripe_payment_intent_id: str | None = None,
         stripe_payment_method_id: str | None = None,
+        stripe_payment_intent_id: str | None = None,
         stripe_refund_id: str | None = None,
         status: OrderStatus = "processing",
         shipping_name: str | None = None,
@@ -641,9 +646,10 @@ class Order(StoreBaseModel):
             quantity=quantity,
             stripe_checkout_session_id=stripe_checkout_session_id,
             stripe_product_id=stripe_product_id,
+            stripe_connect_account_id=stripe_connect_account_id,
             stripe_customer_id=stripe_customer_id,
-            stripe_payment_intent_id=stripe_payment_intent_id,
             stripe_payment_method_id=stripe_payment_method_id,
+            stripe_payment_intent_id=stripe_payment_intent_id,
             stripe_refund_id=stripe_refund_id,
             shipping_name=shipping_name,
             shipping_address_line1=shipping_address_line1,

--- a/store/app/model.py
+++ b/store/app/model.py
@@ -585,15 +585,17 @@ class Order(StoreBaseModel):
 
     user_id: str
     user_email: str
-    stripe_checkout_session_id: str
-    stripe_payment_intent_id: str
     created_at: int
     updated_at: int
     status: OrderStatus
     amount: int
     currency: str
     quantity: int
+    stripe_checkout_session_id: str
     stripe_product_id: str
+    stripe_customer_id: str | None = None
+    stripe_payment_intent_id: str | None = None
+    stripe_payment_method_id: str | None = None
     stripe_refund_id: str | None = None
     shipping_name: str | None = None
     shipping_address_line1: str | None = None
@@ -608,12 +610,14 @@ class Order(StoreBaseModel):
         cls,
         user_id: str,
         user_email: str,
-        stripe_checkout_session_id: str,
-        stripe_payment_intent_id: str,
         amount: int,
         currency: str,
         quantity: int,
+        stripe_checkout_session_id: str,
         stripe_product_id: str,
+        stripe_customer_id: str | None = None,
+        stripe_payment_intent_id: str | None = None,
+        stripe_payment_method_id: str | None = None,
         stripe_refund_id: str | None = None,
         status: OrderStatus = "processing",
         shipping_name: str | None = None,
@@ -629,15 +633,17 @@ class Order(StoreBaseModel):
             id=new_uuid(),
             user_id=user_id,
             user_email=user_email,
-            stripe_checkout_session_id=stripe_checkout_session_id,
-            stripe_payment_intent_id=stripe_payment_intent_id,
             created_at=now,
             updated_at=now,
             status=status,
             amount=amount,
             currency=currency,
             quantity=quantity,
+            stripe_checkout_session_id=stripe_checkout_session_id,
             stripe_product_id=stripe_product_id,
+            stripe_customer_id=stripe_customer_id,
+            stripe_payment_intent_id=stripe_payment_intent_id,
+            stripe_payment_method_id=stripe_payment_method_id,
             stripe_refund_id=stripe_refund_id,
             shipping_name=shipping_name,
             shipping_address_line1=shipping_address_line1,

--- a/store/app/model.py
+++ b/store/app/model.py
@@ -51,7 +51,7 @@ class User(StoreBaseModel):
     last_name: str | None = None
     name: str | None = None
     bio: str | None = None
-    stripe_customer_id: str | None = None
+    stripe_customer_ids: dict[str, str] = {}
     stripe_connect_account_id: str | None = None
     stripe_connect_onboarding_completed: bool = False
 
@@ -67,7 +67,7 @@ class User(StoreBaseModel):
         last_name: str | None = None,
         name: str | None = None,
         bio: str | None = None,
-        stripe_customer_id: str | None = None,
+        stripe_customer_ids: dict[str, str] = {},
         stripe_connect_account_id: str | None = None,
         stripe_connect_onboarding_completed: bool = False,
     ) -> Self:
@@ -86,7 +86,7 @@ class User(StoreBaseModel):
             last_name=last_name,
             name=name,
             bio=bio,
-            stripe_customer_id=stripe_customer_id,
+            stripe_customer_ids=stripe_customer_ids,
             stripe_connect_account_id=stripe_connect_account_id,
             stripe_connect_onboarding_completed=stripe_connect_onboarding_completed,
         )

--- a/store/app/routers/listings.py
+++ b/store/app/routers/listings.py
@@ -278,33 +278,31 @@ async def add_listing(
     description: str | None = Form(None),
     child_ids: str = Form(""),
     slug: str = Form(...),
-    price_amount: int | None = Form(None),
+    price_amount: str | None = Form(None),
     currency: str = Form("usd"),
-    inventory_type: Literal["finite", "infinite", "preorder"] = Form("infinite"),
-    inventory_quantity: int | None = Form(None),
-    preorder_release_date: int | None = Form(None),
+    inventory_type: Literal["finite", "preorder"] = Form("finite"),
+    inventory_quantity: str | None = Form(None),
+    preorder_release_date: str | None = Form(None),
     is_reservation: bool = Form(False),
-    reservation_deposit_amount: int | None = Form(None),
+    reservation_deposit_amount: str | None = Form(None),
     photos: List[UploadFile] = File(None),
 ) -> NewListingResponse:
     try:
         logger.info("Starting to process add listing request")
 
-        # Initialize variables
+        # Convert string values to appropriate types
+        price_amount_int = int(price_amount) if price_amount else None
+        inventory_quantity_int = int(inventory_quantity) if inventory_quantity else None
+        preorder_release_date_int = int(float(preorder_release_date)) if preorder_release_date else None
+        reservation_deposit_amount_int = int(reservation_deposit_amount) if reservation_deposit_amount else None
+
+        # Initialize Stripe-related variables
         stripe_product_id = None
         stripe_price_id = None
-        deposit_price_id = None  # Initialize here
-
-        # Validation checks
-        if price_amount is not None and price_amount <= 0:
-            logger.error("Validation failed: Price amount must be greater than 0")
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Price amount must be greater than 0",
-            )
+        deposit_price_id = None
 
         # Create Stripe product if price is set
-        if price_amount is not None and user.stripe_connect_account_id:
+        if price_amount_int is not None and user.stripe_connect_account_id:
             try:
                 product = stripe.Product.create(
                     name=name,
@@ -314,30 +312,29 @@ async def add_listing(
                     },
                     stripe_account=user.stripe_connect_account_id,
                 )
+                stripe_product_id = product.id
 
                 price = stripe.Price.create(
                     product=product.id,
                     currency=currency,
-                    unit_amount=price_amount,
+                    unit_amount=price_amount_int,
                     metadata={
-                        "inventory_quantity": str(inventory_quantity) if inventory_type == "finite" else "",
-                        "preorder_release_date": str(preorder_release_date) if inventory_type == "preorder" else "",
+                        "inventory_quantity": str(inventory_quantity_int) if inventory_type == "finite" else "",
+                        "preorder_release_date": str(preorder_release_date_int) if inventory_type == "preorder" else "",
                     },
                     stripe_account=user.stripe_connect_account_id,
                 )
+                stripe_price_id = price.id
 
-                if is_reservation and reservation_deposit_amount:
+                if is_reservation and reservation_deposit_amount_int:
                     deposit_price = stripe.Price.create(
                         product=product.id,
                         currency=currency,
-                        unit_amount=reservation_deposit_amount,
+                        unit_amount=reservation_deposit_amount_int,
                         metadata={"is_deposit": "true"},
                         stripe_account=user.stripe_connect_account_id,
                     )
                     deposit_price_id = deposit_price.id
-
-                stripe_product_id = product.id
-                stripe_price_id = price.id
 
             except stripe.StripeError as e:
                 logger.error(f"Stripe error: {str(e)}")
@@ -353,13 +350,13 @@ async def add_listing(
             child_ids=child_ids.split(",") if child_ids else [],
             slug=slug,
             user_id=user.id,
-            price_amount=price_amount,
+            price_amount=price_amount_int,
             currency=currency,
             inventory_type=inventory_type,
-            inventory_quantity=inventory_quantity,
-            preorder_release_date=preorder_release_date,
+            inventory_quantity=inventory_quantity_int,
+            preorder_release_date=preorder_release_date_int,
             is_reservation=is_reservation,
-            reservation_deposit_amount=reservation_deposit_amount,
+            reservation_deposit_amount=reservation_deposit_amount_int,
             stripe_product_id=stripe_product_id,
             stripe_price_id=stripe_price_id,
             stripe_deposit_price_id=deposit_price_id,

--- a/store/app/routers/stripe.py
+++ b/store/app/routers/stripe.py
@@ -301,13 +301,12 @@ async def create_checkout_session(
                 metadata["stripe_product_id"] = listing.stripe_product_id
 
             # Determine payment methods based on listing type and price
-            payment_methods = ["card"]
+            payment_methods: list[str] = ["card"]
             if listing.price_amount >= 5000 and listing.inventory_type != "preorder":
-                # Only add Affirm for non-preorder items
                 payment_methods.append("affirm")
 
             # Base checkout session parameters
-            checkout_params = {
+            checkout_params: dict[str, Any] = {
                 "line_items": [
                     {
                         "price": platform_price.id,
@@ -343,8 +342,9 @@ async def create_checkout_session(
 
             # Add setup_future_usage for preorders to save payment method
             if listing.inventory_type == "preorder":
+                if "payment_intent_data" not in checkout_params:
+                    checkout_params["payment_intent_data"] = {}
                 checkout_params["payment_intent_data"]["setup_future_usage"] = "off_session"
-                # Add custom text about saving payment info for preorders
                 checkout_params["custom_text"] = {
                     "submit": {
                         "message": (


### PR DESCRIPTION
**What does this PR do?**
1. Preorders trigger customer creation under listing owner's connected stripe account
2. Customers under seller's stripe account also have saved payment method for future charge
3. Users now have array of customer id's mapped to various connected seller accounts

TODO:
1. temp: only allow user's with admin permission to create listings with pre-order option
2. fix standard flow
3. reduce duplicate payment methods saved
4. adjust our internal order model/route to work with new stripe preorder flow