### PR TITLE
Listing general/edit/delete UI/UX improvements

### DIFF
--- a/frontend/src/components/listing/ListingDeleteButton.tsx
+++ b/frontend/src/components/listing/ListingDeleteButton.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { FaTrash } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 
-import Modal from "@/components/ui/Modal";
+import DeleteConfirmationModal from "@/components/modals/DeleteConfirmationModal";
 import { Button } from "@/components/ui/button";
 import { useAlertQueue } from "@/hooks/useAlertQueue";
 import { useAuthentication } from "@/hooks/useAuth";
@@ -77,31 +77,13 @@ const ListingDeleteButton = (props: Props) => {
         <FaTrash className="mr-2 h-4 w-4" />
         <span>{deleting ? "Deleting..." : "Delete Listing"}</span>
       </Button>
-      <Modal isOpen={confirmDelete} onClose={() => setConfirmDelete(false)}>
-        <div className="p-8 bg-gray-12 rounded-lg shadow-lg">
-          <h2 className="text-2xl font-bold mb-4 text-gray-2">
-            Confirm Deletion
-          </h2>
-          <p className="mb-6 text-gray-9">
-            Are you sure you want to delete this listing? This action cannot be
-            undone.
-          </p>
-          <div className="flex justify-end space-x-4">
-            <Button onClick={() => setConfirmDelete(false)} variant="outline">
-              Cancel
-            </Button>
-            <Button
-              onClick={() => {
-                handleDelete();
-                setConfirmDelete(false);
-              }}
-              variant="destructive"
-            >
-              Yes, delete
-            </Button>
-          </div>
-        </div>
-      </Modal>
+      <DeleteConfirmationModal
+        isOpen={confirmDelete}
+        onClose={() => setConfirmDelete(false)}
+        onDelete={handleDelete}
+        title="Delete Listing"
+        description="Are you sure you want to delete this listing? This action cannot be undone."
+      />
     </>
   );
 };

--- a/frontend/src/components/listing/ListingImageCarousel.tsx
+++ b/frontend/src/components/listing/ListingImageCarousel.tsx
@@ -11,7 +11,7 @@ interface Props {
   setCurrentImageIndex: React.Dispatch<React.SetStateAction<number>>;
 }
 
-const ListingImageFlipper = (props: Props) => {
+const ListingImageCarousel = (props: Props) => {
   const { artifacts, name, currentImageIndex, setCurrentImageIndex } = props;
   const [isFullScreen, setIsFullScreen] = useState(false);
 
@@ -86,6 +86,22 @@ const ListingImageFlipper = (props: Props) => {
             >
               <FaChevronRight className="text-gray-11" />
             </button>
+            {/* Dot indicators */}
+            <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-2">
+              {imageArtifacts.map((_, index) => (
+                <button
+                  key={index}
+                  onClick={() =>
+                    setCurrentImageIndex(imageArtifacts[index].originalIndex)
+                  }
+                  className={`w-2 h-2 rounded-full transition-colors ${
+                    index === currentImageArrayIndex
+                      ? "bg-white"
+                      : "bg-white/40"
+                  }`}
+                />
+              ))}
+            </div>
           </>
         )}
       </div>
@@ -112,4 +128,4 @@ const ListingImageFlipper = (props: Props) => {
   );
 };
 
-export default ListingImageFlipper;
+export default ListingImageCarousel;

--- a/frontend/src/components/listing/ListingImageGallery.tsx
+++ b/frontend/src/components/listing/ListingImageGallery.tsx
@@ -2,9 +2,11 @@ import { useState } from "react";
 import { FaStar, FaTimes } from "react-icons/fa";
 
 import { Artifact } from "@/components/listing/types";
+import DeleteConfirmationModal from "@/components/modals/DeleteConfirmationModal";
 import { useAlertQueue } from "@/hooks/useAlertQueue";
 import { useAuthentication } from "@/hooks/useAuth";
 
+import { Tooltip } from "../ui/ToolTip";
 import { Button } from "../ui/button";
 import ListingArtifactRenderer from "./ListingArtifactRenderer";
 
@@ -38,12 +40,12 @@ const ListingImageItem = ({
 }) => {
   const [isDeleting, setIsDeleting] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   const auth = useAuthentication();
   const { addErrorAlert } = useAlertQueue();
 
-  const handleDelete = async (e: React.MouseEvent) => {
-    e.stopPropagation();
+  const handleDelete = async () => {
     setIsDeleting(true);
     try {
       const response = await auth.client.DELETE(
@@ -120,42 +122,56 @@ const ListingImageItem = ({
   };
 
   return (
-    <div
-      key={artifact.urls.large}
-      className={`aspect-square rounded-lg overflow-hidden cursor-pointer relative ${
-        currentImageIndex === index ? "ring-2 ring-blue-500" : ""
-      } ${artifact.is_main ? "ring-2 ring-green-500" : ""}`}
-      onClick={() => setCurrentImageIndex(index)}
-    >
-      <ListingArtifactRenderer artifact={artifact} />
-      {canEdit && (
-        <div className="absolute top-2 right-2 flex gap-2">
-          {!artifact.is_main && artifact.artifact_type === "image" && (
-            <Button
-              variant="default"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleSetMain(e);
-              }}
-              disabled={isUpdating}
-              className="hover:bg-green-600 text-white"
-            >
-              <FaStar />
-            </Button>
-          )}
-          <Button
-            variant={isDeleting ? "ghost" : "destructive"}
-            onClick={(e) => {
-              e.stopPropagation();
-              handleDelete(e);
-            }}
-            disabled={isDeleting}
-          >
-            <FaTimes />
-          </Button>
-        </div>
-      )}
-    </div>
+    <>
+      <div
+        key={artifact.urls.large}
+        className={`aspect-square rounded-lg overflow-hidden cursor-pointer relative ${
+          currentImageIndex === index ? "ring-2 ring-gray-7" : ""
+        } ${artifact.is_main ? "ring-2 ring-white" : ""}`}
+        onClick={() => setCurrentImageIndex(index)}
+      >
+        <ListingArtifactRenderer artifact={artifact} />
+        {canEdit && (
+          <div className="absolute top-2 right-2 flex gap-2">
+            {!artifact.is_main && artifact.artifact_type === "image" && (
+              <Tooltip content="Set as Main Image" position="left" size="sm">
+                <Button
+                  variant="default"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleSetMain(e);
+                  }}
+                  disabled={isUpdating}
+                  className="text-gray-1 hover:bg-gray-1 hover:text-gray-12"
+                >
+                  <FaStar />
+                </Button>
+              </Tooltip>
+            )}
+            <Tooltip content="Delete Image" position="left" size="sm">
+              <Button
+                variant={isDeleting ? "ghost" : "destructive"}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowDeleteModal(true);
+                }}
+                disabled={isDeleting}
+              >
+                <FaTimes />
+              </Button>
+            </Tooltip>
+          </div>
+        )}
+      </div>
+      <DeleteConfirmationModal
+        isOpen={showDeleteModal}
+        onClose={() => setShowDeleteModal(false)}
+        onDelete={handleDelete}
+        title="Delete Image"
+        description="Are you sure you want to delete this image? This action cannot be undone."
+        buttonText="Delete Image"
+      />
+    </>
   );
 };
 

--- a/frontend/src/components/listing/ListingMetadata.tsx
+++ b/frontend/src/components/listing/ListingMetadata.tsx
@@ -60,9 +60,11 @@ const ListingMetadata = ({
 
         {/* Stats */}
         <span className="flex items-center gap-1">
-          <FaEye /> {views} views
+          <FaEye /> <span className="ml-1 text-gray-7">{views} views</span>
         </span>
-        <span>Posted {new Date(createdAt * 1000).toLocaleDateString()}</span>
+        <span className="text-xs">
+          Posted {new Date(createdAt * 1000).toLocaleDateString()}
+        </span>
       </div>
     </>
   );

--- a/frontend/src/components/listing/ListingName.tsx
+++ b/frontend/src/components/listing/ListingName.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
-import { FaPencilAlt, FaSave, FaTimes } from "react-icons/fa";
+import { FaPen, FaSave, FaTimes } from "react-icons/fa";
 
+import { Button } from "@/components/ui/button";
 import { useAlertQueue } from "@/hooks/useAlertQueue";
 import { useAuthentication } from "@/hooks/useAuth";
 
@@ -55,48 +56,50 @@ const ListingName = (props: Props) => {
   };
 
   return (
-    <div className="flex justify-between items-center">
+    <div className="flex flex-col sm:flex-row gap-2 sm:gap-0 justify-between items-center">
       <h1 className="text-2xl font-normal flex items-center gap-2">
         {isEditing ? (
-          <div className="flex items-center gap-2">
+          <div className="flex flex-col sm:flex-row items-center gap-2">
             <input
               type="text"
               value={newName}
               onChange={handleChange}
-              className="border rounded px-2 py-1 bg-black text-white"
+              className="border rounded px-2 py-1 bg-black text-white sm:mr-2"
               disabled={submitting}
             />
-            <button
-              onClick={handleSave}
-              disabled={submitting}
-              className="text-green-600 hover:text-green-700 disabled:text-gray-400"
-            >
-              <FaSave />
-            </button>
-            <button
-              onClick={() => {
-                setIsEditing(false);
-                setNewName(name);
-                setHasChanged(false);
-              }}
-              disabled={submitting}
-              className="text-red-600 hover:text-red-700 disabled:text-gray-400"
-            >
-              <FaTimes />
-            </button>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => {
+                  setIsEditing(false);
+                  setNewName(name);
+                  setHasChanged(false);
+                }}
+                disabled={submitting}
+                className="text-red-600 hover:text-red-700 disabled:text-gray-400"
+              >
+                <FaTimes />
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={submitting}
+                className="text-green-500/80 hover:text-green-500/60 disabled:text-gray-400"
+              >
+                <FaSave />
+              </button>
+            </div>
           </div>
         ) : (
           <>
-            {name}
+            <span className="sm:mr-2">{name}</span>
             {edit && (
-              <button
-                className="text-gray-500 hover:text-gray-700"
+              <Button
                 onClick={() => setIsEditing(true)}
+                variant="ghost"
+                size="icon"
+                disabled={submitting}
               >
-                <span className="text-sm">
-                  <FaPencilAlt />
-                </span>
-              </button>
+                <FaPen />
+              </Button>
             )}
           </>
         )}

--- a/frontend/src/components/listing/ListingRenderer.tsx
+++ b/frontend/src/components/listing/ListingRenderer.tsx
@@ -4,7 +4,7 @@ import ListingDeleteButton from "@/components/listing/ListingDeleteButton";
 import ListingDescription from "@/components/listing/ListingDescription";
 import ListingFeatureButton from "@/components/listing/ListingFeatureButton";
 import ListingFileUpload from "@/components/listing/ListingFileUpload";
-import ListingImageFlipper from "@/components/listing/ListingImageFlipper";
+import ListingImageCarousel from "@/components/listing/ListingImageCarousel";
 import ListingImageGallery from "@/components/listing/ListingImageGallery";
 import ListingMetadata from "@/components/listing/ListingMetadata";
 import ListingName from "@/components/listing/ListingName";
@@ -64,7 +64,7 @@ const ListingRenderer = ({ listing }: { listing: ListingResponse }) => {
     <div className="max-w-6xl mx-auto sm:p-4 sm:pt-8">
       {/* Main content area - flex column on mobile, row on desktop */}
       <div className="flex flex-col md:flex-row gap-8 mb-8 items-start">
-        <ListingImageFlipper
+        <ListingImageCarousel
           artifacts={artifacts}
           name={name}
           currentImageIndex={currentImageIndex}
@@ -123,6 +123,12 @@ const ListingRenderer = ({ listing }: { listing: ListingResponse }) => {
           {/* Build this robot */}
           <div className="flex flex-col sm:flex-row sm:items-baseline gap-4">
             <div className="grid grid-cols-1 xs:grid-cols-3 gap-4 w-full">
+              <ListingRegisterRobot listingId={listingId} className="w-full" />
+              <ListingFeatureButton
+                listingId={listingId}
+                initialFeatured={isFeatured}
+                className="w-full"
+              />
               {canEdit && (
                 <ListingDeleteButton
                   listingId={listingId}
@@ -130,12 +136,6 @@ const ListingRenderer = ({ listing }: { listing: ListingResponse }) => {
                   initialFeatured={isFeatured}
                 />
               )}
-              <ListingFeatureButton
-                listingId={listingId}
-                initialFeatured={isFeatured}
-                className="w-full"
-              />
-              <ListingRegisterRobot listingId={listingId} className="w-full" />
             </div>
           </div>
         </div>

--- a/frontend/src/components/listing/ListingVote.tsx
+++ b/frontend/src/components/listing/ListingVote.tsx
@@ -63,24 +63,24 @@ const ListingVote = ({ listingId, userVote: initialUserVote }: Props) => {
   };
 
   return (
-    <div className="flex items-center gap-2 text-gray-600">
+    <div className="flex items-center gap-2 text-gray-3">
       <button
-        className={`p-1 hover:bg-gray-100 rounded ${
-          userVote === true && !voting ? "text-green-500" : ""
-        }`}
-        onClick={() => handleVote(true)}
-        disabled={voting || !auth.isAuthenticated}
-      >
-        <FaArrowUp />
-      </button>
-      <button
-        className={`p-1 hover:bg-gray-100 rounded ${
+        className={`p-1 hover:bg-gray-1 hover:text-gray-12 rounded ${
           userVote === false && !voting ? "text-red-500" : ""
         }`}
         onClick={() => handleVote(false)}
         disabled={voting || !auth.isAuthenticated}
       >
         <FaArrowDown />
+      </button>
+      <button
+        className={`p-1 hover:bg-gray-1 hover:text-gray-12 rounded ${
+          userVote === true && !voting ? "text-green-500" : ""
+        }`}
+        onClick={() => handleVote(true)}
+        disabled={voting || !auth.isAuthenticated}
+      >
+        <FaArrowUp />
       </button>
     </div>
   );

--- a/frontend/src/components/modals/DeleteConfirmationModal.tsx
+++ b/frontend/src/components/modals/DeleteConfirmationModal.tsx
@@ -1,0 +1,45 @@
+import Modal from "@/components/ui/Modal";
+import { Button } from "@/components/ui/button";
+
+interface DeleteConfirmationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onDelete: () => void;
+  title?: string;
+  description?: string;
+  buttonText?: string;
+}
+
+const DeleteConfirmationModal = ({
+  isOpen,
+  onClose,
+  onDelete,
+  title = "Confirm Deletion",
+  description = "Are you sure you want to delete this? This action cannot be undone.",
+  buttonText = "Yes, delete",
+}: DeleteConfirmationModalProps) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="p-8 bg-gray-12 rounded-lg shadow-lg">
+        <h2 className="text-2xl font-bold mb-4 text-gray-2">{title}</h2>
+        <p className="mb-6 text-gray-7">{description}</p>
+        <div className="flex justify-end space-x-4">
+          <Button onClick={onClose} variant="outline">
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              onDelete();
+              onClose();
+            }}
+            variant="destructive"
+          >
+            {buttonText}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default DeleteConfirmationModal;

--- a/frontend/src/components/ui/Input/Input.tsx
+++ b/frontend/src/components/ui/Input/Input.tsx
@@ -47,7 +47,7 @@ const TextArea = React.forwardRef<
         ring-offset-background file:border-0 bg-gray-3
         file:text-sm file:font-medium placeholder:text-gray-9
         focus-visible:outline-none focus-visible:ring-2
-        focus-visible:ring-ring focus-visible:ring-offset-2
+        focus-visible:ring-ring
         disabled:cursor-not-allowed disabled:opacity-50
         text-gray-12`,
         className,


### PR DESCRIPTION
**What does this PR do?**
1. Created reusable delete confirmation modal takes title, description, button text, and a custom onDelete function from parent (this should be used whenever a delete action is available to the user)
2. Listing Image display has doc indicators for indices
3. Hover over image delete and feature buttons now show tooltip indicating what the actions do
4. Listing image delete now uses delete confirmation
5. **Fixed mobile UI** when editing listing title (it used to cause horizontal overflow)
6. Improve color/contrast ratio on various text/bg instances

Things to consider for future:
1. Listing deletion also deletes stripe product (if possible?)
  - If stripe product has been interacted with, Stripe does not allow product deletion, offers archiving instead
2. What stripe/purchase related fields on the listing are safe to allow editing for (to reduce the need for fully deleting listing to edit things such as price etc)
  - release date should be fine
  - price/preorder deposits may be an issue due to past purchases/other misc cases

## Listing header UI improvements, Image gallery has dot indicators (bottom) for indices
<img width="720" alt="Screenshot 2024-11-16 at 8 18 12 AM" src="https://github.com/user-attachments/assets/210f418b-c828-4e7c-ad6c-5c61e371b6ca">

## Reusable delete confirmation (Delete listing clicked)
<img width="720" alt="Screenshot 2024-11-16 at 8 20 52 AM" src="https://github.com/user-attachments/assets/f1090b6e-6c64-4502-aca9-635d4ac00105">

## Hover over image delete tooltip
<img width="432" alt="Screenshot 2024-11-16 at 8 18 54 AM" src="https://github.com/user-attachments/assets/cc85cbe2-616b-41a0-9e49-ffa0f52a0afa">

## Hover over image set as thumbnail/main tooltip
<img width="432" alt="Screenshot 2024-11-16 at 8 19 01 AM" src="https://github.com/user-attachments/assets/2ba34546-2280-482d-bd14-699436460758">

