### PR TITLE
hide store section from non-profile owners & handle empty orders as a…

### DIFF
--- a/frontend/src/components/pages/Profile.tsx
+++ b/frontend/src/components/pages/Profile.tsx
@@ -181,6 +181,12 @@ export const RenderProfile = (props: RenderProfileProps) => {
     }
   };
 
+  const getListingsTabLabel = () => {
+    return canEdit
+      ? "Your Robot Listings"
+      : `${user.first_name || user.username}'s Robot Listings`;
+  };
+
   return (
     <div className="space-y-8 mb-12">
       <Card className="w-full max-w-4xl mx-auto">
@@ -274,67 +280,72 @@ export const RenderProfile = (props: RenderProfileProps) => {
 
       <Card className="w-full max-w-4xl mx-auto">
         <CardHeader>
-          <h2 className="text-2xl font-bold">Store</h2>
+          {canEdit && <h2 className="text-2xl font-bold">Store</h2>}
         </CardHeader>
         <CardContent>
-          <div className="mb-4">
-            {user.stripe_connect &&
-            !user.stripe_connect.onboarding_completed ? (
-              <p className="text-gray-6 text-sm">
-                Your Stripe account setup is not complete. Please resolve
-                outstanding requirements to begin selling robots. It may take
-                some time for Stripe to process your info between submissions.
-              </p>
-            ) : user.stripe_connect &&
-              user.stripe_connect.onboarding_completed ? (
-              <p className="text-gray-6 text-sm">
-                You are set up to sell robots on K-Scale.
-              </p>
-            ) : (
-              <p>Complete seller onboarding to sell robots on K-Scale</p>
-            )}
-          </div>
-          <div className="flex sm:flex-row flex-col gap-2 mb-8">
-            <Tooltip content="View your orders" position="bottom">
-              <Button
-                onClick={() => navigate(ROUTES.ORDERS.path)}
-                variant="outline"
-              >
-                Orders
-              </Button>
-            </Tooltip>
-            {!user.stripe_connect ? (
-              <Tooltip content="Start selling on K-Scale" position="bottom">
-                <Button
-                  onClick={() => navigate(ROUTES.SELL.ONBOARDING.path)}
-                  variant="outline"
-                >
-                  Start Seller Onboarding
-                </Button>
-              </Tooltip>
-            ) : !user.stripe_connect.onboarding_completed ? (
-              <Tooltip content="Continue onboarding" position="bottom">
-                <Button
-                  onClick={() => navigate(ROUTES.SELL.ONBOARDING.path)}
-                  variant="outline"
-                >
-                  Complete Seller Onboarding
-                </Button>
-              </Tooltip>
-            ) : (
-              <Tooltip
-                content="Sell Robots or View Your Dashboard"
-                position="bottom"
-              >
-                <Button
-                  onClick={() => navigate(ROUTES.SELL.DASHBOARD.path)}
-                  variant="outline"
-                >
-                  Seller Dashboard
-                </Button>
-              </Tooltip>
-            )}
-          </div>
+          {canEdit && (
+            <>
+              <div className="mb-4">
+                {user.stripe_connect &&
+                !user.stripe_connect.onboarding_completed ? (
+                  <p className="text-gray-6 text-sm">
+                    Your Stripe account setup is not complete. Please resolve
+                    outstanding requirements to begin selling robots. It may
+                    take some time for Stripe to process your info between
+                    submissions.
+                  </p>
+                ) : user.stripe_connect &&
+                  user.stripe_connect.onboarding_completed ? (
+                  <p className="text-gray-6 text-sm">
+                    You are set up to sell robots on K-Scale.
+                  </p>
+                ) : (
+                  <p>Complete seller onboarding to sell robots on K-Scale</p>
+                )}
+              </div>
+              <div className="flex sm:flex-row flex-col gap-2 mb-8">
+                <Tooltip content="View your orders" position="bottom">
+                  <Button
+                    onClick={() => navigate(ROUTES.ORDERS.path)}
+                    variant="outline"
+                  >
+                    Orders
+                  </Button>
+                </Tooltip>
+                {!user.stripe_connect ? (
+                  <Tooltip content="Start selling on K-Scale" position="bottom">
+                    <Button
+                      onClick={() => navigate(ROUTES.SELL.ONBOARDING.path)}
+                      variant="outline"
+                    >
+                      Start Seller Onboarding
+                    </Button>
+                  </Tooltip>
+                ) : !user.stripe_connect.onboarding_completed ? (
+                  <Tooltip content="Continue onboarding" position="bottom">
+                    <Button
+                      onClick={() => navigate(ROUTES.SELL.ONBOARDING.path)}
+                      variant="outline"
+                    >
+                      Complete Seller Onboarding
+                    </Button>
+                  </Tooltip>
+                ) : (
+                  <Tooltip
+                    content="Sell Robots or View Your Dashboard"
+                    position="bottom"
+                  >
+                    <Button
+                      onClick={() => navigate(ROUTES.SELL.DASHBOARD.path)}
+                      variant="outline"
+                    >
+                      Seller Dashboard
+                    </Button>
+                  </Tooltip>
+                )}
+              </div>
+            </>
+          )}
           <div className="flex flex-col items-center space-y-4">
             <Tabs
               defaultValue="own"
@@ -352,28 +363,32 @@ export const RenderProfile = (props: RenderProfileProps) => {
                     value="own"
                     className="data-[state=active]:bg-gray-3"
                   >
-                    Your Robot Listings
+                    {getListingsTabLabel()}
                   </TabsTrigger>
                 </Button>
-                <Button
-                  variant="outline"
-                  asChild
-                  className={`text-xs sm:text-sm px-2 sm:px-4 hover:bg-gray-11 ${value === "upvoted" ? "border text-gray-12" : ""}`}
-                >
-                  <TabsTrigger
-                    value="upvoted"
-                    className="data-[state=active]:bg-gray-3"
+                {canEdit && (
+                  <Button
+                    variant="outline"
+                    asChild
+                    className={`text-xs sm:text-sm px-2 sm:px-4 hover:bg-gray-11 ${value === "upvoted" ? "border text-gray-12" : ""}`}
                   >
-                    Upvoted Robots
-                  </TabsTrigger>
-                </Button>
+                    <TabsTrigger
+                      value="upvoted"
+                      className="data-[state=active]:bg-gray-3"
+                    >
+                      Upvoted Robots
+                    </TabsTrigger>
+                  </Button>
+                )}
               </TabsList>
               <TabsContent value="own">
                 <MyListingGrid userId={user.id} />
               </TabsContent>
-              <TabsContent value="upvoted">
-                <UpvotedGrid page={upvotedPage} setPage={setUpvotedPage} />
-              </TabsContent>
+              {canEdit && (
+                <TabsContent value="upvoted">
+                  <UpvotedGrid page={upvotedPage} setPage={setUpvotedPage} />
+                </TabsContent>
+              )}
             </Tabs>
           </div>
         </CardContent>

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -6,6 +6,8 @@ export interface ApiValidationError {
 }
 
 export interface ApiError {
+  status: number;
+  message: string;
   detail: string | ApiValidationError[];
 }
 


### PR DESCRIPTION
… valid state

**What does this PR do?**

- Restricts visibility of the 'Store' section to profile owners only
- Ensures store functionality is accessible only to the profile owner
- Gracefully manages the "no orders" state by returning an empty array instead of a 404
- Removes console logs showing false-positive 404 errors for empty order lists
