### PR TITLE
Improve order api endpoints

### DIFF
--- a/frontend/src/components/modals/CancelOrderModal.tsx
+++ b/frontend/src/components/modals/CancelOrderModal.tsx
@@ -11,9 +11,7 @@ import { Label } from "@/components/ui/label";
 import { paths } from "@/gen/api";
 import { useAlertQueue } from "@/hooks/useAlertQueue";
 import { useAuthentication } from "@/hooks/useAuth";
-
-type Order =
-  paths["/orders/user-orders"]["get"]["responses"][200]["content"]["application/json"][0];
+import type { OrderWithProduct } from "@/lib/types/orders";
 
 type RefundRequest =
   paths["/stripe/refunds/{order_id}"]["put"]["requestBody"]["content"]["application/json"];
@@ -21,8 +19,8 @@ type RefundRequest =
 interface CancelOrderModalProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
-  order: Order;
-  onOrderUpdate: (updatedOrder: Order) => void;
+  order: OrderWithProduct;
+  onOrderUpdate: (updatedOrder: OrderWithProduct) => void;
 }
 
 const CancelOrderModal: React.FC<CancelOrderModalProps> = ({
@@ -90,7 +88,7 @@ const CancelOrderModal: React.FC<CancelOrderModalProps> = ({
 
     try {
       const { data, error } = await client.PUT("/stripe/refunds/{order_id}", {
-        params: { path: { order_id: order.id } },
+        params: { path: { order_id: order.order.id } },
         body: cancellation,
       });
 
@@ -99,7 +97,10 @@ const CancelOrderModal: React.FC<CancelOrderModalProps> = ({
         console.error("Error canceling order:", error);
       } else {
         addAlert("Order successfully canceled", "success");
-        onOrderUpdate(data);
+        onOrderUpdate({
+          order: data,
+          product: order.product,
+        });
       }
 
       onOpenChange(false);

--- a/frontend/src/components/modals/EditAddressModal.tsx
+++ b/frontend/src/components/modals/EditAddressModal.tsx
@@ -9,18 +9,15 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { paths } from "@/gen/api";
 import { useAlertQueue } from "@/hooks/useAlertQueue";
 import { useAuthentication } from "@/hooks/useAuth";
-
-type Order =
-  paths["/orders/user-orders"]["get"]["responses"][200]["content"]["application/json"][0];
+import type { OrderWithProduct } from "@/lib/types/orders";
 
 interface EditAddressModalProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
-  order: Order;
-  onOrderUpdate: (updatedOrder: Order) => void;
+  order: OrderWithProduct;
+  onOrderUpdate: (updatedOrder: OrderWithProduct) => void;
 }
 
 const EditAddressModal: React.FC<EditAddressModalProps> = ({
@@ -32,13 +29,13 @@ const EditAddressModal: React.FC<EditAddressModalProps> = ({
   const { client } = useAuthentication();
   const { addAlert, addErrorAlert } = useAlertQueue();
   const [address, setAddress] = useState({
-    shipping_name: order.shipping_name || "",
-    shipping_address_line1: order.shipping_address_line1 || "",
-    shipping_address_line2: order.shipping_address_line2 || "",
-    shipping_city: order.shipping_city || "",
-    shipping_state: order.shipping_state || "",
-    shipping_postal_code: order.shipping_postal_code || "",
-    shipping_country: order.shipping_country || "",
+    shipping_name: order.order.shipping_name || "",
+    shipping_address_line1: order.order.shipping_address_line1 || "",
+    shipping_address_line2: order.order.shipping_address_line2 || "",
+    shipping_city: order.order.shipping_city || "",
+    shipping_state: order.order.shipping_state || "",
+    shipping_postal_code: order.order.shipping_postal_code || "",
+    shipping_country: order.order.shipping_country || "",
   });
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -50,9 +47,9 @@ const EditAddressModal: React.FC<EditAddressModalProps> = ({
     e.preventDefault();
     try {
       const { data, error } = await client.PUT(
-        "/orders/update-order-address/{order_id}",
+        "/orders/{order_id}/shipping-address",
         {
-          params: { path: { order_id: order.id } },
+          params: { path: { order_id: order.order.id } },
           body: address,
         },
       );
@@ -62,7 +59,10 @@ const EditAddressModal: React.FC<EditAddressModalProps> = ({
         console.error("Error updating address:", error);
       } else {
         addAlert("Delivery address updated", "success");
-        onOrderUpdate(data);
+        onOrderUpdate({
+          order: data,
+          product: order.product,
+        });
       }
 
       onOpenChange(false);

--- a/frontend/src/components/orders/OrderCard.tsx
+++ b/frontend/src/components/orders/OrderCard.tsx
@@ -8,15 +8,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import type { paths } from "@/gen/api";
+import type { OrderWithProduct } from "@/lib/types/orders";
 import { formatPrice } from "@/lib/utils/formatNumber";
 import { normalizeStatus } from "@/lib/utils/formatString";
-
-type OrderWithProduct =
-  paths["/orders/user-orders-with-products"]["get"]["responses"][200]["content"]["application/json"][0];
-
-type Order =
-  paths["/orders/user-orders"]["get"]["responses"][200]["content"]["application/json"][0];
 
 enum OrderStatus {
   PREORDER = -1,
@@ -60,7 +54,7 @@ const canModifyStatuses = [
 const OrderCard: React.FC<{ orderWithProduct: OrderWithProduct }> = ({
   orderWithProduct: initialOrderWithProduct,
 }) => {
-  const [orderWithProduct, setOrderWithProduct] = useState(
+  const [orderWithProduct, setOrderWithProduct] = useState<OrderWithProduct>(
     initialOrderWithProduct,
   );
   const { order, product } = orderWithProduct;
@@ -92,8 +86,8 @@ const OrderCard: React.FC<{ orderWithProduct: OrderWithProduct }> = ({
 
   const unitPrice = order.price_amount / order.quantity;
 
-  const handleOrderUpdate = (updatedOrder: Order) => {
-    setOrderWithProduct((prev) => ({ ...prev, order: updatedOrder }));
+  const handleOrderUpdate = (updatedOrder: OrderWithProduct) => {
+    setOrderWithProduct(updatedOrder);
   };
 
   const canModifyOrder = () => {
@@ -281,13 +275,13 @@ const OrderCard: React.FC<{ orderWithProduct: OrderWithProduct }> = ({
       <EditAddressModal
         isOpen={isEditAddressModalOpen}
         onOpenChange={setIsEditAddressModalOpen}
-        order={order}
+        order={orderWithProduct}
         onOrderUpdate={handleOrderUpdate}
       />
       <CancelOrderModal
         isOpen={isCancelOrderModalOpen}
         onOpenChange={setIsCancelOrderModalOpen}
-        order={order}
+        order={orderWithProduct}
         onOrderUpdate={handleOrderUpdate}
       />
     </div>

--- a/frontend/src/components/pages/Orders.tsx
+++ b/frontend/src/components/pages/Orders.tsx
@@ -22,9 +22,7 @@ const OrdersPage: React.FC = () => {
       if (isAuthenticated && currentUser) {
         setLoadingOrders(true);
         try {
-          const { data, error } = await api.client.GET("/orders/me", {
-            params: { query: { include_products: true } },
-          });
+          const { data, error } = await api.client.GET("/orders/me");
 
           if (error) {
             const apiError = error as ApiError;

--- a/frontend/src/components/pages/Orders.tsx
+++ b/frontend/src/components/pages/Orders.tsx
@@ -13,7 +13,7 @@ import ROUTES from "@/lib/types/routes";
 const OrdersPage: React.FC = () => {
   const navigate = useNavigate();
   const { api, currentUser, isAuthenticated, isLoading } = useAuthentication();
-  const [orders, setOrders] = useState<OrderWithProduct[] | null>(null);
+  const [orders, setOrders] = useState<OrderWithProduct[]>([]);
   const [loadingOrders, setLoadingOrders] = useState(true);
   const { addErrorAlert } = useAlertQueue();
 
@@ -65,7 +65,7 @@ const OrdersPage: React.FC = () => {
         <div className="flex justify-center items-center p-4 md:p-10 rounded-lg max-w-md mx-auto">
           <Spinner className="p-1" />
         </div>
-      ) : orders && orders.length > 0 ? (
+      ) : orders.length > 0 ? (
         <div className="grid gap-2 md:gap-6 md:grid-cols-1 lg:grid-cols-2">
           {orders.map((orderWithProduct: OrderWithProduct) => (
             <OrderCard

--- a/frontend/src/components/pages/Orders.tsx
+++ b/frontend/src/components/pages/Orders.tsx
@@ -4,14 +4,11 @@ import { useNavigate } from "react-router-dom";
 import OrderCard from "@/components/orders/OrderCard";
 import Spinner from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
-import type { paths } from "@/gen/api";
 import { useAlertQueue } from "@/hooks/useAlertQueue";
 import { useAuthentication } from "@/hooks/useAuth";
 import { ApiError } from "@/lib/types/api";
+import type { OrderWithProduct } from "@/lib/types/orders";
 import ROUTES from "@/lib/types/routes";
-
-type OrderWithProduct =
-  paths["/orders/user-orders-with-products"]["get"]["responses"][200]["content"]["application/json"][number];
 
 const OrdersPage: React.FC = () => {
   const navigate = useNavigate();
@@ -25,9 +22,10 @@ const OrdersPage: React.FC = () => {
       if (isAuthenticated && currentUser) {
         setLoadingOrders(true);
         try {
-          const { data, error } = await api.client.GET(
-            "/orders/user-orders-with-products",
-          );
+          const { data, error } = await api.client.GET("/orders/me", {
+            params: { query: { include_products: true } },
+          });
+
           if (error) {
             const apiError = error as ApiError;
             if (apiError.status === 500) {
@@ -38,7 +36,7 @@ const OrdersPage: React.FC = () => {
             }
             setOrders([]);
           } else {
-            setOrders(data || []);
+            setOrders(data as OrderWithProduct[]);
           }
         } finally {
           setLoadingOrders(false);

--- a/frontend/src/components/pages/SellerOnboarding.tsx
+++ b/frontend/src/components/pages/SellerOnboarding.tsx
@@ -64,7 +64,6 @@ export default function SellerOnboarding() {
 
       if (data?.account_id) {
         setConnectedAccountId(data.account_id);
-        // Refresh user data to get updated stripe connect account id
         await auth.fetchCurrentUser();
       }
     } catch (error) {

--- a/frontend/src/components/stripe/CheckoutButton.tsx
+++ b/frontend/src/components/stripe/CheckoutButton.tsx
@@ -59,7 +59,7 @@ const CheckoutButton: React.FC<Props> = ({
 
     try {
       const { data, error } = await auth.client.POST(
-        "/stripe/create-checkout-session",
+        "/stripe/checkout-session",
         {
           body: {
             listing_id: listingId,

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -869,10 +869,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /**
-         * Stripe Webhook
-         * @description Handle direct account webhooks (non-Connect events).
-         */
+        /** Stripe Webhook */
         post: operations["stripe_webhook_stripe_webhook_post"];
         delete?: never;
         options?: never;
@@ -889,10 +886,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /**
-         * Stripe Connect Webhook
-         * @description Handle Connect account webhooks.
-         */
+        /** Stripe Connect Webhook */
         post: operations["stripe_connect_webhook_stripe_connect_webhook_post"];
         delete?: never;
         options?: never;

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -652,24 +652,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/orders/user-orders": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get User Orders */
-        get: operations["get_user_orders_orders_user_orders_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/orders/order/{order_id}": {
+    "/orders/{order_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -677,7 +660,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get Order */
-        get: operations["get_order_orders_order__order_id__get"];
+        get: operations["get_order_orders__order_id__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -686,15 +669,15 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/orders/order-with-product/{order_id}": {
+    "/orders/me": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Get Order With Product */
-        get: operations["get_order_with_product_orders_order_with_product__order_id__get"];
+        /** Get User Orders */
+        get: operations["get_user_orders_orders_me_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -703,24 +686,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/orders/user-orders-with-products": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get User Orders With Products */
-        get: operations["get_user_orders_with_products_orders_user_orders_with_products_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/orders/update-order-address/{order_id}": {
+    "/orders/{order_id}/shipping-address": {
         parameters: {
             query?: never;
             header?: never;
@@ -728,8 +694,8 @@ export interface paths {
             cookie?: never;
         };
         get?: never;
-        /** Update Order Address */
-        put: operations["update_order_address_orders_update_order_address__order_id__put"];
+        /** Update Order Shipping Address */
+        put: operations["update_order_shipping_address_orders__order_id__shipping_address_put"];
         post?: never;
         delete?: never;
         options?: never;
@@ -1777,7 +1743,7 @@ export interface components {
         /** OrderWithProduct */
         OrderWithProduct: {
             order: components["schemas"]["Order"];
-            product: components["schemas"]["ProductInfo"];
+            product: components["schemas"]["ProductInfo"] | null;
         };
         /** ProductInfo */
         ProductInfo: {
@@ -3296,60 +3262,11 @@ export interface operations {
             };
         };
     };
-    get_user_orders_orders_user_orders_get: {
+    get_order_orders__order_id__get: {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Order"][];
-                };
+            query?: {
+                include_product?: boolean;
             };
-        };
-    };
-    get_order_orders_order__order_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                order_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Order"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_order_with_product_orders_order_with_product__order_id__get: {
-        parameters: {
-            query?: never;
             header?: never;
             path: {
                 order_id: string;
@@ -3378,9 +3295,11 @@ export interface operations {
             };
         };
     };
-    get_user_orders_with_products_orders_user_orders_with_products_get: {
+    get_user_orders_orders_me_get: {
         parameters: {
-            query?: never;
+            query?: {
+                include_products?: boolean;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -3396,9 +3315,18 @@ export interface operations {
                     "application/json": components["schemas"]["OrderWithProduct"][];
                 };
             };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
     };
-    update_order_address_orders_update_order_address__order_id__put: {
+    update_order_shipping_address_orders__order_id__shipping_address_put: {
         parameters: {
             query?: never;
             header?: never;

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -900,7 +900,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/stripe/create-checkout-session": {
+    "/stripe/checkout-session": {
         parameters: {
             query?: never;
             header?: never;
@@ -910,7 +910,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Create Checkout Session */
-        post: operations["create_checkout_session_stripe_create_checkout_session_post"];
+        post: operations["create_checkout_session_stripe_checkout_session_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1354,6 +1354,15 @@ export interface components {
             /** Order Id */
             order_id?: string | null;
         };
+        /** DeleteTestAccountsResponse */
+        DeleteTestAccountsResponse: {
+            /** Success */
+            success: boolean;
+            /** Deleted Accounts */
+            deleted_accounts: string[];
+            /** Count */
+            count: number;
+        };
         /** DeleteTokenResponse */
         DeleteTokenResponse: {
             /** Message */
@@ -1745,6 +1754,13 @@ export interface components {
             order: components["schemas"]["Order"];
             product: components["schemas"]["ProductInfo"] | null;
         };
+        /** ProcessPreorderResponse */
+        ProcessPreorderResponse: {
+            /** Status */
+            status: string;
+            /** Checkout Session */
+            checkout_session: Record<string, never> | null;
+        };
         /** ProductInfo */
         ProductInfo: {
             /** Id */
@@ -1759,6 +1775,25 @@ export interface components {
             metadata: {
                 [key: string]: string;
             };
+            /** Active */
+            active: boolean;
+        };
+        /** ProductResponse */
+        ProductResponse: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+            /** Images */
+            images: string[];
+            /** Metadata */
+            metadata: {
+                [key: string]: string;
+            };
+            /** Active */
+            active: boolean;
         };
         /** PublicUserInfoResponseItem */
         PublicUserInfoResponseItem: {
@@ -3264,9 +3299,7 @@ export interface operations {
     };
     get_order_orders__order_id__get: {
         parameters: {
-            query?: {
-                include_product?: boolean;
-            };
+            query?: never;
             header?: never;
             path: {
                 order_id: string;
@@ -3297,9 +3330,7 @@ export interface operations {
     };
     get_user_orders_orders_me_get: {
         parameters: {
-            query?: {
-                include_products?: boolean;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
@@ -3313,15 +3344,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["OrderWithProduct"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -3650,7 +3672,7 @@ export interface operations {
             };
         };
     };
-    create_checkout_session_stripe_create_checkout_session_post: {
+    create_checkout_session_stripe_checkout_session_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -3700,7 +3722,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["ProductResponse"];
                 };
             };
             /** @description Validation Error */
@@ -3784,7 +3806,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["DeleteTestAccountsResponse"];
                 };
             };
         };
@@ -3806,7 +3828,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["ProcessPreorderResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/lib/types/orders.ts
+++ b/frontend/src/lib/types/orders.ts
@@ -1,0 +1,17 @@
+import type { paths } from "@/gen/api";
+
+export type Order =
+  paths["/orders/{order_id}"]["get"]["responses"][200]["content"]["application/json"];
+
+export type OrderWithProduct =
+  paths["/orders/{order_id}"]["get"]["responses"][200]["content"]["application/json"] & {
+    product: ProductInfo;
+  };
+
+export type ProductInfo = {
+  id: string;
+  name: string;
+  description: string | null;
+  images: string[];
+  metadata: Record<string, string>;
+};

--- a/store/app/crud/orders.py
+++ b/store/app/crud/orders.py
@@ -52,6 +52,12 @@ class OrderDataUpdate(TypedDict):
     shipping_country: NotRequired[str]
 
 
+class OrdersNotFoundError(ItemNotFoundError):
+    """Raised when no orders are found for a user."""
+
+    pass
+
+
 class OrdersCrud(BaseCrud):
     """CRUD operations for Orders."""
 
@@ -63,7 +69,7 @@ class OrdersCrud(BaseCrud):
     async def get_orders_by_user_id(self, user_id: str) -> list[Order]:
         orders = await self._get_items_from_secondary_index("user_id", user_id, Order)
         if not orders:
-            raise ItemNotFoundError("No orders found for this user")
+            raise OrdersNotFoundError(f"No orders found for user {user_id}")
         return orders
 
     async def get_orders_by_stripe_connect_account_id(self, stripe_connect_account_id: str) -> list[Order]:

--- a/store/app/crud/orders.py
+++ b/store/app/crud/orders.py
@@ -88,26 +88,16 @@ class OrdersCrud(BaseCrud):
         if not order:
             raise ItemNotFoundError("Order not found")
 
-        # Create a dict of current order data
         current_data = order.model_dump()
-
-        # Convert TypedDict to regular dict
-        update_dict = dict(update_data)  # Convert TypedDict to regular dict
-
-        # Update with new data
+        update_dict = dict(update_data)
         current_data.update(update_dict)
 
         try:
-            # Validate the updated data
             Order(**current_data)
         except ValidationError as e:
-            # If validation fails, raise an error
             raise ValueError(f"Invalid update data: {str(e)}")
 
-        # If validation passes, update the order
         await self._update_item(order_id, Order, update_dict)
-
-        # Fetch and return the updated order
         updated_order = await self.get_order(order_id)
         if not updated_order:
             raise ItemNotFoundError("Updated order not found")

--- a/store/app/model.py
+++ b/store/app/model.py
@@ -572,6 +572,7 @@ InventoryType = Literal["finite", "preorder"]
 class Order(StoreBaseModel):
     """Tracks completed user orders through Stripe."""
 
+    id: str
     user_id: str
     listing_id: str
     user_email: str

--- a/store/app/model.py
+++ b/store/app/model.py
@@ -572,7 +572,6 @@ InventoryType = Literal["finite", "preorder"]
 class Order(StoreBaseModel):
     """Tracks completed user orders through Stripe."""
 
-    id: str
     user_id: str
     listing_id: str
     user_email: str

--- a/store/app/routers/listings.py
+++ b/store/app/routers/listings.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Annotated, List, Literal
+from typing import Annotated, Literal
 
 from fastapi import (
     APIRouter,
@@ -283,7 +283,7 @@ async def add_listing(
     inventory_quantity: str | None = Form(None),
     preorder_deposit_amount: str | None = Form(None),
     preorder_release_date: str | None = Form(None),
-    photos: List[UploadFile] = File(None),
+    photos: list[UploadFile] = File(None),
 ) -> NewListingResponse:
     try:
         logger.info("Starting to process add listing request")

--- a/store/app/utils/cloudfront_signer.py
+++ b/store/app/utils/cloudfront_signer.py
@@ -5,7 +5,7 @@ The `CloudFrontUrlSigner` class allows you to create and sign CloudFront URLs wi
 
 import json
 from datetime import datetime, timedelta
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from botocore.signers import CloudFrontSigner
 from cryptography.hazmat.primitives import hashes, serialization
@@ -66,7 +66,7 @@ class CloudFrontUrlSigner:
         :return: The custom policy in JSON format.
         """
         expiration_time = int((datetime.utcnow() + timedelta(days=expire_days)).timestamp())
-        policy: Dict[str, Any] = {
+        policy: dict[str, Any] = {
             "Statement": [
                 {
                     "Resource": url,


### PR DESCRIPTION
**What does this PR do?**
1. Removed all instances of `typing.List` and `typing.Dict` and use standard `list` and `dict`
2. Standardized naming convention for `Order` endpoints.
