### PR TITLE
Order Refunds, updated refund/address modals, removed dead order code

### DIFF
--- a/frontend/src/components/modals/CancelOrderModal.tsx
+++ b/frontend/src/components/modals/CancelOrderModal.tsx
@@ -1,12 +1,7 @@
 import React, { useState } from "react";
 
+import Modal from "@/components/ui/Modal";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { paths } from "@/gen/api";
 import { useAlertQueue } from "@/hooks/useAlertQueue";
@@ -43,9 +38,9 @@ const CancelOrderModal: React.FC<CancelOrderModalProps> = ({
   const MAX_REASON_LENGTH = 500;
 
   const [cancellation, setCancellation] = useState<RefundRequest>({
-    payment_intent_id: "",
+    payment_intent_id: order.order.stripe_payment_intent_id,
     cancel_reason: { reason: "", details: "" },
-    amount: 0,
+    amount: order.order.price_amount,
   });
   const [customReason, setCustomReason] = useState("");
 
@@ -81,11 +76,6 @@ const CancelOrderModal: React.FC<CancelOrderModalProps> = ({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (!cancellation.payment_intent_id) {
-      addErrorAlert("Invalid payment information");
-      return;
-    }
-
     try {
       const { data, error } = await client.PUT("/stripe/refunds/{order_id}", {
         params: { path: { order_id: order.order.id } },
@@ -110,15 +100,13 @@ const CancelOrderModal: React.FC<CancelOrderModalProps> = ({
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px] bg-gray-1 text-gray-12 border border-gray-3 rounded-lg shadow-lg">
-        <DialogHeader>
-          <DialogTitle>Cancel Order</DialogTitle>
-        </DialogHeader>
+    <Modal isOpen={isOpen} onClose={() => onOpenChange(false)}>
+      <div className="p-6">
+        <h2 className="text-xl font-semibold mb-4">Cancel Order</h2>
         <form onSubmit={handleSubmit}>
-          <div className="grid gap-4 py-4">
+          <div className="grid gap-4 py-4 mb-4">
             <div className="grid gap-2">
-              <Label htmlFor="cancel_reason">Cancel Reason</Label>
+              <Label htmlFor="cancel_reason">Reason for cancelling</Label>
               <select
                 id="cancel_reason"
                 name="cancel_reason"
@@ -127,7 +115,7 @@ const CancelOrderModal: React.FC<CancelOrderModalProps> = ({
                 className="bg-gray-2 border-gray-3 text-gray-12 rounded-md p-2"
               >
                 <option value="" disabled>
-                  Select a reason for cancellation
+                  Select a reason for cancelling
                 </option>
                 {cancellationReasons.map((reason) => (
                   <option key={reason} value={reason}>
@@ -156,21 +144,18 @@ const CancelOrderModal: React.FC<CancelOrderModalProps> = ({
           <div className="flex justify-end gap-2">
             <Button
               type="button"
-              variant="outline"
+              variant="default"
               onClick={() => onOpenChange(false)}
             >
               Cancel
             </Button>
-            <Button
-              type="submit"
-              className="bg-primary-9 text-gray-1 hover:bg-gray-12"
-            >
+            <Button type="submit" variant="outline">
               Save Changes
             </Button>
           </div>
         </form>
-      </DialogContent>
-    </Dialog>
+      </div>
+    </Modal>
   );
 };
 

--- a/frontend/src/components/modals/CancelOrderModal.tsx
+++ b/frontend/src/components/modals/CancelOrderModal.tsx
@@ -40,7 +40,11 @@ const CancelOrderModal: React.FC<CancelOrderModalProps> = ({
   const [cancellation, setCancellation] = useState<RefundRequest>({
     payment_intent_id: order.order.stripe_payment_intent_id,
     cancel_reason: { reason: "", details: "" },
-    amount: order.order.price_amount,
+    amount:
+      order.order.status === "preorder_placed" &&
+      order.order.preorder_deposit_amount
+        ? order.order.preorder_deposit_amount
+        : order.order.price_amount,
   });
   const [customReason, setCustomReason] = useState("");
 

--- a/frontend/src/components/modals/EditAddressModal.tsx
+++ b/frontend/src/components/modals/EditAddressModal.tsx
@@ -122,25 +122,27 @@ const EditAddressModal: React.FC<EditAddressModalProps> = ({
                 className="bg-gray-2 border-gray-3 text-gray-12"
               />
             </div>
-            <div className="grid gap-2">
-              <Label htmlFor="shipping_postal_code">Postal Code</Label>
-              <Input
-                id="shipping_postal_code"
-                name="shipping_postal_code"
-                value={address.shipping_postal_code}
-                onChange={handleInputChange}
-                className="bg-gray-2 border-gray-3 text-gray-12"
-              />
-            </div>
-            <div className="grid gap-2">
-              <Label htmlFor="shipping_country">Country</Label>
-              <Input
-                id="shipping_country"
-                name="shipping_country"
-                value={address.shipping_country}
-                onChange={handleInputChange}
-                className="bg-gray-2 border-gray-3 text-gray-12"
-              />
+            <div className="grid grid-cols-2 gap-3">
+              <div className="grid gap-2">
+                <Label htmlFor="shipping_postal_code">Postal Code</Label>
+                <Input
+                  id="shipping_postal_code"
+                  name="shipping_postal_code"
+                  value={address.shipping_postal_code}
+                  onChange={handleInputChange}
+                  className="bg-gray-2 border-gray-3 text-gray-12"
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="shipping_country">Country</Label>
+                <Input
+                  id="shipping_country"
+                  name="shipping_country"
+                  value={address.shipping_country}
+                  onChange={handleInputChange}
+                  className="bg-gray-2 border-gray-3 text-gray-12"
+                />
+              </div>
             </div>
           </div>
           <div className="flex justify-end gap-2">

--- a/frontend/src/components/modals/EditAddressModal.tsx
+++ b/frontend/src/components/modals/EditAddressModal.tsx
@@ -1,12 +1,7 @@
 import React, { useState } from "react";
 
+import Modal from "@/components/ui/Modal";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useAlertQueue } from "@/hooks/useAlertQueue";
@@ -47,7 +42,7 @@ const EditAddressModal: React.FC<EditAddressModalProps> = ({
     e.preventDefault();
     try {
       const { data, error } = await client.PUT(
-        "/orders/{order_id}/shipping-address",
+        "/orders/shipping-address/{order_id}",
         {
           params: { path: { order_id: order.order.id } },
           body: address,
@@ -72,13 +67,11 @@ const EditAddressModal: React.FC<EditAddressModalProps> = ({
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px] bg-gray-1 text-gray-12 border border-gray-3 rounded-lg shadow-lg">
-        <DialogHeader>
-          <DialogTitle>Edit Delivery Address</DialogTitle>
-        </DialogHeader>
+    <Modal isOpen={isOpen} onClose={() => onOpenChange(false)}>
+      <div className="p-6">
+        <h2 className="text-xl font-semibold mb-4">Edit Delivery Address</h2>
         <form onSubmit={handleSubmit}>
-          <div className="grid gap-4 py-4">
+          <div className="grid gap-3 py-4">
             <div className="grid gap-2">
               <Label htmlFor="shipping_name">Name</Label>
               <Input
@@ -153,21 +146,18 @@ const EditAddressModal: React.FC<EditAddressModalProps> = ({
           <div className="flex justify-end gap-2">
             <Button
               type="button"
-              variant="outline"
+              variant="default"
               onClick={() => onOpenChange(false)}
             >
               Cancel
             </Button>
-            <Button
-              type="submit"
-              className="bg-primary-9 text-gray-1 hover:bg-gray-12"
-            >
+            <Button type="submit" variant="outline">
               Save Changes
             </Button>
           </div>
         </form>
-      </DialogContent>
-    </Dialog>
+      </div>
+    </Modal>
   );
 };
 

--- a/frontend/src/components/orders/OrderCard.tsx
+++ b/frontend/src/components/orders/OrderCard.tsx
@@ -45,6 +45,7 @@ const activeStatuses = [
 
 const redStatuses = ["cancelled", "refunded", "failed"];
 const canModifyStatuses = [
+  "preorder_placed",
   "processing",
   "in_development",
   "being_assembled",
@@ -124,6 +125,14 @@ const OrderCard: React.FC<{ orderWithProduct: OrderWithProduct }> = ({
         </div>
       )}
 
+      {order.status === "refunded" && order.preorder_deposit_amount && (
+        <div className="mb-4 p-3 bg-gray-4 text-gray-12 rounded-md">
+          <p className="font-medium">
+            Pre-order Deposit: {formatPrice(order.preorder_deposit_amount)}
+          </p>
+        </div>
+      )}
+
       {order.status === "awaiting_final_payment" && (
         <div className="mb-4 p-3 bg-gray-4 text-gray-12 rounded-md">
           <p className="font-medium">
@@ -143,7 +152,14 @@ const OrderCard: React.FC<{ orderWithProduct: OrderWithProduct }> = ({
         <p>Order ID: {order.id}</p>
         <div className="mb-2">
           <DropdownMenu>
-            <DropdownMenuTrigger className="text-gray-12 underline cursor-pointer">
+            <DropdownMenuTrigger
+              className={`underline ${
+                !canModifyOrder()
+                  ? "text-gray-11 cursor-not-allowed"
+                  : "text-gray-12 cursor-pointer"
+              }`}
+              disabled={!canModifyOrder()}
+            >
               Manage order
             </DropdownMenuTrigger>
             <DropdownMenuContent>

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -12,10 +12,10 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div
-        className="absolute inset-0 bg-gray-1 opacity-50"
+        className="absolute inset-0 bg-gray-11 opacity-50"
         onClick={onClose}
       ></div>
-      <div className="bg-gray-2 rounded-lg z-10 max-w-md w-full">
+      <div className="bg-gray-12 rounded-lg z-10 max-w-md w-full">
         {children}
       </div>
     </div>

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -652,23 +652,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/orders/{order_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Order */
-        get: operations["get_order_orders__order_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/orders/me": {
         parameters: {
             query?: never;
@@ -686,7 +669,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/orders/{order_id}/shipping-address": {
+    "/orders/{order_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Order */
+        get: operations["get_order_orders__order_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/orders/shipping-address/{order_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -695,7 +695,7 @@ export interface paths {
         };
         get?: never;
         /** Update Order Shipping Address */
-        put: operations["update_order_shipping_address_orders__order_id__shipping_address_put"];
+        put: operations["update_order_shipping_address_orders_shipping_address__order_id__put"];
         post?: never;
         delete?: never;
         options?: never;
@@ -1700,7 +1700,7 @@ export interface components {
             /** Stripe Price Id */
             stripe_price_id: string;
             /** Stripe Payment Intent Id */
-            stripe_payment_intent_id?: string | null;
+            stripe_payment_intent_id: string;
             /** Preorder Release Date */
             preorder_release_date?: number | null;
             /** Preorder Deposit Amount */
@@ -3291,6 +3291,26 @@ export interface operations {
             };
         };
     };
+    get_user_orders_orders_me_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrderWithProduct"][];
+                };
+            };
+        };
+    };
     get_order_orders__order_id__get: {
         parameters: {
             query?: never;
@@ -3322,27 +3342,7 @@ export interface operations {
             };
         };
     };
-    get_user_orders_orders_me_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrderWithProduct"][];
-                };
-            };
-        };
-    };
-    update_order_shipping_address_orders__order_id__shipping_address_put: {
+    update_order_shipping_address_orders_shipping_address__order_id__put: {
         parameters: {
             query?: never;
             header?: never;

--- a/store/app/crud/orders.py
+++ b/store/app/crud/orders.py
@@ -22,7 +22,7 @@ class OrderDataCreate(TypedDict):
     stripe_product_id: str
     stripe_price_id: str
     stripe_connect_account_id: str
-    stripe_payment_intent_id: NotRequired[str | None]
+    stripe_payment_intent_id: str
     preorder_release_date: NotRequired[int | None]
     preorder_deposit_amount: NotRequired[int | None]
     stripe_preorder_deposit_id: NotRequired[str | None]

--- a/store/app/model.py
+++ b/store/app/model.py
@@ -585,7 +585,7 @@ class Order(StoreBaseModel):
     stripe_connect_account_id: str
     stripe_product_id: str
     stripe_price_id: str
-    stripe_payment_intent_id: str | None = None
+    stripe_payment_intent_id: str
     preorder_release_date: int | None = None
     preorder_deposit_amount: int | None = None
     stripe_preorder_deposit_id: str | None = None
@@ -619,7 +619,7 @@ class Order(StoreBaseModel):
         quantity: int,
         price_amount: int,
         currency: str,
-        stripe_payment_intent_id: str | None = None,
+        stripe_payment_intent_id: str,
         preorder_release_date: int | None = None,
         preorder_deposit_amount: int | None = None,
         stripe_preorder_deposit_id: str | None = None,

--- a/store/app/routers/orders.py
+++ b/store/app/routers/orders.py
@@ -67,7 +67,7 @@ async def get_user_orders(
             results = await asyncio.gather(*[get_product_info(order) for order in orders])
             return results
 
-    except OrdersNotFoundError as e:
+    except OrdersNotFoundError:
         logger.info(f"No orders found for user: {user.id}")
         return []
     except Exception as e:
@@ -89,7 +89,6 @@ async def get_order(
         if not order or order.user_id != user.id:
             raise HTTPException(status_code=404, detail="Order not found")
 
-        # Get product info from Stripe
         product = await stripe.get_product(order.stripe_product_id, crud)
 
         # Convert ProductResponse to ProductInfo
@@ -115,7 +114,7 @@ class UpdateOrderAddressRequest(BaseModel):
     shipping_country: str
 
 
-@router.put("/{order_id}/shipping-address", response_model=Order)
+@router.put("/shipping-address/{order_id}", response_model=Order)
 async def update_order_shipping_address(
     order_id: str,
     address_update: UpdateOrderAddressRequest,

--- a/store/app/routers/orders.py
+++ b/store/app/routers/orders.py
@@ -1,7 +1,7 @@
 """Defines the router endpoints for handling Orders."""
 
 import asyncio
-from logging import getLogger
+import logging
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -17,7 +17,7 @@ from store.app.security.user import (
 
 router = APIRouter()
 
-logger = getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class ProductInfo(BaseModel):
@@ -32,33 +32,6 @@ class ProductInfo(BaseModel):
 class OrderWithProduct(BaseModel):
     order: Order
     product: ProductInfo | None
-
-
-@router.get("/{order_id}", response_model=OrderWithProduct)
-async def get_order(
-    order_id: str,
-    user: User = Depends(get_session_user_with_read_permission),
-    crud: Crud = Depends(),
-) -> OrderWithProduct:
-    async with crud:
-        order = await crud.get_order(order_id)
-        if not order or order.user_id != user.id:
-            raise HTTPException(status_code=404, detail="Order not found")
-
-        # Get product info from Stripe
-        product = await stripe.get_product(order.stripe_product_id, crud)
-
-        # Convert ProductResponse to ProductInfo
-        product_info = ProductInfo(
-            id=product.id,
-            name=product.name,
-            description=product.description,
-            images=product.images,
-            metadata=product.metadata,
-            active=product.active,
-        )
-
-        return OrderWithProduct(order=order, product=product_info)
 
 
 @router.get("/me", response_model=list[OrderWithProduct])
@@ -89,24 +62,47 @@ async def get_user_orders(
             return OrderWithProduct(order=order, product=None)
 
     try:
-        orders = await crud.get_orders_by_user_id(user.id)
-        return await asyncio.gather(*[get_product_info(order) for order in orders])
-    except OrdersNotFoundError:
+        async with crud:
+            orders = await crud.get_orders_by_user_id(user.id)
+            results = await asyncio.gather(*[get_product_info(order) for order in orders])
+            return results
+
+    except OrdersNotFoundError as e:
+        logger.info(f"No orders found for user: {user.id}")
         return []
-    except asyncio.TimeoutError:
-        logger.error("Timeout while fetching orders", extra={"user_id": user.id})
-        raise HTTPException(
-            status_code=status.HTTP_504_GATEWAY_TIMEOUT, detail="Request timed out while fetching orders"
-        )
     except Exception as e:
-        logger.error(
-            "Unexpected error fetching user orders",
-            extra={"user_id": user.id, "error": str(e), "error_type": type(e).__name__},
-        )
+        logger.error(f"Error fetching orders: {str(e)}", exc_info=True)
+        print(f"Error fetching orders: {str(e)}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="An unexpected error occurred while fetching orders",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Error fetching orders: {str(e)}"
         )
+
+
+@router.get("/{order_id}", response_model=OrderWithProduct)
+async def get_order(
+    order_id: str,
+    user: User = Depends(get_session_user_with_read_permission),
+    crud: Crud = Depends(),
+) -> OrderWithProduct:
+    async with crud:
+        order = await crud.get_order(order_id)
+        if not order or order.user_id != user.id:
+            raise HTTPException(status_code=404, detail="Order not found")
+
+        # Get product info from Stripe
+        product = await stripe.get_product(order.stripe_product_id, crud)
+
+        # Convert ProductResponse to ProductInfo
+        product_info = ProductInfo(
+            id=product.id,
+            name=product.name,
+            description=product.description,
+            images=product.images,
+            metadata=product.metadata,
+            active=product.active,
+        )
+
+        return OrderWithProduct(order=order, product=product_info)
 
 
 class UpdateOrderAddressRequest(BaseModel):


### PR DESCRIPTION
**What does this PR do?**
1. Finished Order cancellation/refunds (triggered by user who placed the order) for both preorder and standard orders
2. Removed unused order functions
3. Updated Cancel Order and Edit Address Modals
4. Improved naming convention for order edit address endpoint

## Updated Edit Delivery Address Modal
attachments/assets/f68c6cd5-5334-49e4-a012-40f9415d3eac">
<img width="1000" alt="Screenshot 2024-11-18 at 12 38 52 PM" src="https://github.com/user-attachments/assets/6fcf97aa-2d28-4f53-94a2-be4e0111714f">


## Cancel Order -> Stripe Refund Successfully Processed
<img width="720" alt="Screenshot 2024-11-18 at 12 15 09 PM" src="https://github.com/user-attachments/assets/e3dd3046-d3ed-4f6a-bc0b-77a3d3256e47">
