### PR TITLE
Admin dashboard for managing orders

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import Navbar from "@/components/nav/Navbar";
 import APIKeys from "@/components/pages/APIKeys";
 import About from "@/components/pages/About";
 import Account from "@/components/pages/Account";
+import AdminDashboard from "@/components/pages/AdminDashboard";
 import Browse from "@/components/pages/Browse";
 import CreateSell from "@/components/pages/CreateSell";
 import CreateShare from "@/components/pages/CreateShare";
@@ -161,6 +162,11 @@ const App = () => {
                         <Route
                           path={ROUTES.LINK.path}
                           element={<LinkRobot />}
+                        />
+
+                        <Route
+                          path={ROUTES.ADMIN.path}
+                          element={<AdminDashboard />}
                         />
 
                         {/* Not found */}

--- a/frontend/src/components/admin/AdminManageOrder.tsx
+++ b/frontend/src/components/admin/AdminManageOrder.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from "react";
+
+import AdminProcessPreorderModal from "@/components/modals/AdminProcessPreorderModal";
+import AdminUpdateStatusModal from "@/components/modals/AdminUpdateStatusModal";
+import CancelOrderModal from "@/components/modals/CancelOrderModal";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { OrderWithProduct } from "@/lib/types/orders";
+import { canModifyOrder } from "@/lib/utils/orders";
+
+interface AdminManageOrderProps {
+  order: OrderWithProduct;
+  onOrderUpdate?: (updatedOrder: OrderWithProduct) => void;
+}
+
+const AdminManageOrder: React.FC<AdminManageOrderProps> = ({
+  order,
+  onOrderUpdate,
+}) => {
+  const [isStatusModalOpen, setIsStatusModalOpen] = useState(false);
+  const [isPreorderModalOpen, setIsPreorderModalOpen] = useState(false);
+  const [isCancelOrderModalOpen, setIsCancelOrderModalOpen] = useState(false);
+
+  const handleOrderUpdate = (updatedOrder: OrderWithProduct) => {
+    if (onOrderUpdate) {
+      onOrderUpdate(updatedOrder);
+    }
+  };
+
+  const showPreorderOption =
+    order.order.preorder_deposit_amount &&
+    order.order.status !== "awaiting_final_payment" &&
+    order.order.status !== "cancelled" &&
+    order.order.status !== "refunded";
+
+  return (
+    <div className="mb-4 p-2 bg-primary/10 rounded-md">
+      <div className="flex justify-between items-center">
+        <span className="text-primary font-semibold">Admin Controls</span>
+        <DropdownMenu>
+          <DropdownMenuTrigger className="text-primary underline hover:text-primary/80 hover:underline-offset-2">
+            Manage Order
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem
+              disabled={!canModifyOrder(order)}
+              onSelect={() => setIsStatusModalOpen(true)}
+              className="cursor-pointer"
+            >
+              Change order status
+            </DropdownMenuItem>
+            {showPreorderOption && (
+              <>
+                <div className="border-t border-gray-200 my-1"></div>
+                <DropdownMenuItem
+                  disabled={!canModifyOrder(order)}
+                  onSelect={() => setIsPreorderModalOpen(true)}
+                  className="cursor-pointer"
+                >
+                  Process pre-order
+                </DropdownMenuItem>
+              </>
+            )}
+            <div className="border-t border-gray-200 my-1"></div>
+            <DropdownMenuItem
+              disabled={!canModifyOrder(order)}
+              onSelect={() => setIsCancelOrderModalOpen(true)}
+              className="cursor-pointer"
+            >
+              Cancel order
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <AdminUpdateStatusModal
+        isOpen={isStatusModalOpen}
+        onOpenChange={setIsStatusModalOpen}
+        order={order}
+        onOrderUpdate={handleOrderUpdate}
+      />
+
+      <AdminProcessPreorderModal
+        isOpen={isPreorderModalOpen}
+        onOpenChange={setIsPreorderModalOpen}
+        order={order}
+        onOrderUpdate={handleOrderUpdate}
+      />
+
+      <CancelOrderModal
+        isOpen={isCancelOrderModalOpen}
+        onOpenChange={setIsCancelOrderModalOpen}
+        order={order}
+        onOrderUpdate={handleOrderUpdate}
+      />
+    </div>
+  );
+};
+
+export default AdminManageOrder;

--- a/frontend/src/components/modals/AdminProcessPreorderModal.tsx
+++ b/frontend/src/components/modals/AdminProcessPreorderModal.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from "react";
+
+import Modal from "@/components/ui/Modal";
+import { Button } from "@/components/ui/button";
+import { useAlertQueue } from "@/hooks/useAlertQueue";
+import { useAuthentication } from "@/hooks/useAuth";
+import type { OrderWithProduct } from "@/lib/types/orders";
+import { formatPrice } from "@/lib/utils/formatNumber";
+
+interface AdminProcessPreorderModalProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  order: OrderWithProduct;
+  onOrderUpdate: (updatedOrder: OrderWithProduct) => void;
+}
+
+const AdminProcessPreorderModal: React.FC<AdminProcessPreorderModalProps> = ({
+  isOpen,
+  onOpenChange,
+  order,
+  onOrderUpdate,
+}) => {
+  const { api } = useAuthentication();
+  const { addAlert, addErrorAlert } = useAlertQueue();
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const handleProcessPreorder = async () => {
+    setIsProcessing(true);
+    try {
+      const { data, error } = await api.client.POST(
+        "/stripe/process/preorder/{order_id}",
+        {
+          params: {
+            path: { order_id: order.order.id },
+          },
+        },
+      );
+
+      if (error) {
+        throw error;
+      }
+
+      onOrderUpdate({
+        ...order,
+        order: {
+          ...order.order,
+          status: "awaiting_final_payment",
+          final_payment_checkout_session_id: data.checkout_session.id,
+        },
+      });
+
+      addAlert("Pre-order processed successfully", "success");
+      onOpenChange(false);
+    } catch (error) {
+      console.error(error);
+      addErrorAlert("Failed to process pre-order");
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={() => onOpenChange(false)} size="xl">
+      <div className="p-6 text-gray-1">
+        <h2 className="text-xl font-semibold mb-4">Process Pre-order</h2>
+
+        <div className="space-y-4">
+          <p className="text-gray-6">
+            Are you sure you want to process this pre-order? This will:
+          </p>
+          <ul className="list-disc list-inside text-sm text-gray-8 space-y-1">
+            <li>Mark the order as ready for final payment</li>
+            <li>
+              Request customer to pay remaining balance of{" "}
+              {formatPrice(
+                order.order.price_amount -
+                  (order.order.preorder_deposit_amount || 0),
+              )}
+            </li>
+            <li>Notify the customer via email</li>
+          </ul>
+
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="default"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="outline"
+              onClick={handleProcessPreorder}
+              disabled={isProcessing}
+            >
+              {isProcessing ? "Processing..." : "Process Pre-order"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default AdminProcessPreorderModal;

--- a/frontend/src/components/modals/AdminUpdateStatusModal.tsx
+++ b/frontend/src/components/modals/AdminUpdateStatusModal.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from "react";
+
+import Modal from "@/components/ui/Modal";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { useAlertQueue } from "@/hooks/useAlertQueue";
+import { useAuthentication } from "@/hooks/useAuth";
+import type { OrderWithProduct } from "@/lib/types/orders";
+import { OrderStatus, orderStatuses } from "@/lib/types/orders";
+import { normalizeStatus } from "@/lib/utils/formatString";
+
+interface AdminUpdateStatusModalProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  order: OrderWithProduct;
+  onOrderUpdate: (updatedOrder: OrderWithProduct) => void;
+}
+
+const AdminUpdateStatusModal: React.FC<AdminUpdateStatusModalProps> = ({
+  isOpen,
+  onOpenChange,
+  order,
+  onOrderUpdate,
+}) => {
+  const { api } = useAuthentication();
+  const { addAlert, addErrorAlert } = useAlertQueue();
+  const [selectedStatus, setSelectedStatus] = useState(order.order.status);
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const handleUpdateStatus = async () => {
+    setIsUpdating(true);
+    try {
+      const { data, error } = await api.client.PUT(
+        "/orders/admin/status/{order_id}",
+        {
+          params: {
+            path: { order_id: order.order.id },
+          },
+          body: {
+            status: selectedStatus,
+          },
+        },
+      );
+
+      if (error) {
+        throw error;
+      }
+
+      onOrderUpdate({
+        order: data,
+        product: order.product,
+      });
+
+      addAlert("Order status updated successfully", "success");
+      onOpenChange(false);
+    } catch (error) {
+      console.error(error);
+      addErrorAlert("Failed to update order status");
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={() => onOpenChange(false)}>
+      <div className="p-6 text-gray-1">
+        <h2 className="text-xl font-semibold mb-4">Update Order Status</h2>
+
+        <div className="space-y-4">
+          <div className="grid gap-2">
+            <Label htmlFor="status">Select New Status</Label>
+            <select
+              id="status"
+              value={selectedStatus}
+              onChange={(e) => setSelectedStatus(e.target.value as OrderStatus)}
+              className="bg-gray-2 border-gray-3 text-gray-12 rounded-md p-2"
+            >
+              {orderStatuses.map((status) => (
+                <option key={status} value={status}>
+                  {normalizeStatus(status)}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="default"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="outline"
+              onClick={handleUpdateStatus}
+              disabled={isUpdating || selectedStatus === order.order.status}
+            >
+              {isUpdating ? "Updating..." : "Update Status"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default AdminUpdateStatusModal;

--- a/frontend/src/components/nav/navigation.tsx
+++ b/frontend/src/components/nav/navigation.tsx
@@ -1,5 +1,5 @@
 import { FaRobot, FaTerminal } from "react-icons/fa";
-import { FaRegFileLines } from "react-icons/fa6";
+import { FaChartBar, FaRegFileLines } from "react-icons/fa6";
 
 import ROUTES from "@/lib/types/routes";
 
@@ -34,6 +34,12 @@ const TERMINAL_NAV_ITEM: BaseNavItem = {
   icon: <FaTerminal />,
 };
 
+const ADMIN_DASHBOARD_NAV_ITEM: BaseNavItem = {
+  name: "Admin Dashboard",
+  path: ROUTES.ADMIN.path,
+  icon: <FaChartBar />,
+};
+
 export const AUTHENTICATED_NAV_ITEMS: BaseNavItem[] = [];
 
 export const getNavItems = (
@@ -43,7 +49,7 @@ export const getNavItems = (
   let navItems = [...DEFAULT_NAV_ITEMS];
 
   if (isAdmin) {
-    navItems = [TERMINAL_NAV_ITEM, ...navItems];
+    navItems = [ADMIN_DASHBOARD_NAV_ITEM, TERMINAL_NAV_ITEM, ...navItems];
   }
 
   if (isAuthenticated) {

--- a/frontend/src/components/orders/OrderCard.tsx
+++ b/frontend/src/components/orders/OrderCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 
+import AdminManageOrder from "@/components/admin/AdminManageOrder";
 import CancelOrderModal from "@/components/modals/CancelOrderModal";
 import EditAddressModal from "@/components/modals/EditAddressModal";
 import {
@@ -9,14 +10,10 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { OrderWithProduct } from "@/lib/types/orders";
-import {
-  activeStatuses,
-  canModifyStatuses,
-  orderStatuses,
-  redStatuses,
-} from "@/lib/types/orders";
+import { activeStatuses, orderStatuses, redStatuses } from "@/lib/types/orders";
 import { formatPrice } from "@/lib/utils/formatNumber";
 import { normalizeStatus } from "@/lib/utils/formatString";
+import { canModifyOrder } from "@/lib/utils/orders";
 
 enum OrderStatus {
   PREORDER = -1,
@@ -27,9 +24,10 @@ enum OrderStatus {
   DELIVERED = 4,
 }
 
-const OrderCard: React.FC<{ orderWithProduct: OrderWithProduct }> = ({
-  orderWithProduct: initialOrderWithProduct,
-}) => {
+const OrderCard: React.FC<{
+  orderWithProduct: OrderWithProduct;
+  isAdminView?: boolean;
+}> = ({ orderWithProduct: initialOrderWithProduct, isAdminView }) => {
   const [orderWithProduct, setOrderWithProduct] = useState<OrderWithProduct>(
     initialOrderWithProduct,
   );
@@ -66,13 +64,16 @@ const OrderCard: React.FC<{ orderWithProduct: OrderWithProduct }> = ({
     setOrderWithProduct(updatedOrder);
   };
 
-  const canModifyOrder = () => {
-    return canModifyStatuses.includes(order.status);
-  };
-
   return (
-    <div className="bg-gray-1 shadow-md rounded-lg p-4 md:p-6 w-full">
-      <h2 className="text-gray-12 font-bold text-2xl mb-1">{product.name}</h2>
+    <div className="bg-gray-1 shadow-md rounded-lg p-4 md:p-6 w-full text-gray-12">
+      {isAdminView ? (
+        <AdminManageOrder
+          order={orderWithProduct}
+          onOrderUpdate={handleOrderUpdate}
+        />
+      ) : null}
+
+      <h2 className="font-bold text-2xl mb-1">{product.name}</h2>
       <p className="text-gray-11 mb-1 sm:text-lg">
         Status:{" "}
         <span className={`font-semibold ${getTextColor(order.status)}`}>
@@ -129,17 +130,17 @@ const OrderCard: React.FC<{ orderWithProduct: OrderWithProduct }> = ({
           <DropdownMenu>
             <DropdownMenuTrigger
               className={`underline ${
-                !canModifyOrder()
+                !canModifyOrder(orderWithProduct)
                   ? "text-gray-11 cursor-not-allowed"
                   : "text-gray-12 cursor-pointer"
               }`}
-              disabled={!canModifyOrder()}
+              disabled={!canModifyOrder(orderWithProduct)}
             >
               Manage order
             </DropdownMenuTrigger>
             <DropdownMenuContent>
               <DropdownMenuItem
-                disabled={!canModifyOrder()}
+                disabled={!canModifyOrder(orderWithProduct)}
                 onSelect={() => setIsEditAddressModalOpen(true)}
                 className="cursor-pointer"
               >
@@ -147,7 +148,7 @@ const OrderCard: React.FC<{ orderWithProduct: OrderWithProduct }> = ({
               </DropdownMenuItem>
               <div className="border-t border-gray-11 mx-1"></div>
               <DropdownMenuItem
-                disabled={!canModifyOrder()}
+                disabled={!canModifyOrder(orderWithProduct)}
                 onSelect={() => setIsCancelOrderModalOpen(true)}
                 className="cursor-pointer"
               >

--- a/frontend/src/components/pages/AdminDashboard.tsx
+++ b/frontend/src/components/pages/AdminDashboard.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import OrderCard from "@/components/orders/OrderCard";
+import Spinner from "@/components/ui/Spinner";
+import { useAlertQueue } from "@/hooks/useAlertQueue";
+import { useAuthentication } from "@/hooks/useAuth";
+import { ApiError } from "@/lib/types/api";
+import type { OrderWithProduct } from "@/lib/types/orders";
+import ROUTES from "@/lib/types/routes";
+
+const AdminDashboard = () => {
+  const navigate = useNavigate();
+  const { api, currentUser, isAuthenticated, isLoading } = useAuthentication();
+  const [orders, setOrders] = useState<OrderWithProduct[]>([]);
+  const [loadingOrders, setLoadingOrders] = useState(true);
+  const { addErrorAlert } = useAlertQueue();
+
+  useEffect(() => {
+    const fetchOrders = async () => {
+      if (isAuthenticated && currentUser?.permissions?.includes("is_admin")) {
+        setLoadingOrders(true);
+        try {
+          const { data, error } = await api.client.GET("/orders/admin/all");
+
+          if (error) {
+            const apiError = error as ApiError;
+            addErrorAlert({
+              message: "Failed to fetch orders",
+              detail: apiError.message || "An unexpected error occurred",
+            });
+            setOrders([]);
+          } else {
+            setOrders(data.orders as OrderWithProduct[]);
+          }
+        } finally {
+          setLoadingOrders(false);
+        }
+      }
+    };
+
+    fetchOrders();
+  }, [api, currentUser, isAuthenticated]);
+
+  // Redirect non-admin users
+  useEffect(() => {
+    if (
+      !isLoading &&
+      (!isAuthenticated || !currentUser?.permissions?.includes("is_admin"))
+    ) {
+      navigate(ROUTES.HOME.path);
+    }
+  }, [isLoading, isAuthenticated, currentUser]);
+
+  if (isLoading || loadingOrders) {
+    return (
+      <div className="p-6 min-h-screen">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold">Admin Dashboard</h1>
+          <p className="text-gray-8">
+            View and manage all orders across the platform. Update order
+            statuses, process pre-orders, and cancel orders.
+          </p>
+        </div>
+        <div className="flex justify-center items-center p-4">
+          <Spinner className="p-1" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 min-h-screen">
+      <div className="mb-6">
+        <h1 className="text-3xl font-bold">Admin Dashboard</h1>
+        <p className="text-gray-8">
+          View and manage all orders across the platform. Update order statuses,
+          process pre-orders, and cancel orders.
+        </p>
+      </div>
+
+      <div className="mb-8">
+        <h2 className="text-xl font-semibold mb-4">
+          Viewing All Orders As Admin
+        </h2>
+        {orders.length > 0 ? (
+          <div className="grid gap-2 md:grid-cols-2 lg:grid-cols-3">
+            {orders.map((orderWithProduct) => (
+              <OrderCard
+                key={orderWithProduct.order.id}
+                orderWithProduct={orderWithProduct}
+                isAdminView
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col justify-center items-center">
+            <p className="text-xl text-gray-1">No orders found</p>
+            <p>
+              There are no orders placed yet or no orders that match your query.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -4,9 +4,17 @@ interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
   children: React.ReactNode;
+  className?: string;
+  size?: "sm" | "md" | "lg" | "xl";
 }
 
-const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => {
+const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  children,
+  className,
+  size = "md",
+}) => {
   if (!isOpen) return null;
 
   return (
@@ -15,7 +23,9 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => {
         className="absolute inset-0 bg-gray-11 opacity-50"
         onClick={onClose}
       ></div>
-      <div className="bg-gray-12 rounded-lg z-10 max-w-md w-full">
+      <div
+        className={`bg-gray-12 text-gray-1 rounded-lg z-10 max-w-${size} w-full ${className}`}
+      >
         {children}
       </div>
     </div>

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -703,6 +703,43 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/orders/admin/all": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get All Orders
+         * @description Get all orders (admin only).
+         */
+        get: operations["get_all_orders_orders_admin_all_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/orders/admin/status/{order_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update Order Status */
+        put: operations["update_order_status_orders_admin_status__order_id__put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/robots/create": {
         parameters: {
             query?: never;
@@ -979,7 +1016,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/stripe/process-preorder/{order_id}": {
+    "/stripe/process/preorder/{order_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -1226,6 +1263,11 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** AdminOrdersResponse */
+        AdminOrdersResponse: {
+            /** Orders */
+            orders: components["schemas"]["OrderWithProduct"][];
+        };
         /** ArtifactUrls */
         ArtifactUrls: {
             /** Small */
@@ -1753,7 +1795,7 @@ export interface components {
             /** Status */
             status: string;
             /** Checkout Session */
-            checkout_session: Record<string, never> | null;
+            checkout_session: Record<string, never>;
         };
         /** ProductInfo */
         ProductInfo: {
@@ -1982,6 +2024,14 @@ export interface components {
             shipping_postal_code: string;
             /** Shipping Country */
             shipping_country: string;
+        };
+        /** UpdateOrderStatusRequest */
+        UpdateOrderStatusRequest: {
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "processing" | "in_development" | "being_assembled" | "shipped" | "delivered" | "preorder_placed" | "awaiting_final_payment" | "cancelled" | "refunded";
         };
         /** UpdateRobotRequest */
         UpdateRobotRequest: {
@@ -3354,6 +3404,61 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["UpdateOrderAddressRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Order"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_all_orders_orders_admin_all_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminOrdersResponse"];
+                };
+            };
+        };
+    };
+    update_order_status_orders_admin_status__order_id__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                order_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateOrderStatusRequest"];
             };
         };
         responses: {

--- a/frontend/src/lib/types/orders.ts
+++ b/frontend/src/lib/types/orders.ts
@@ -5,7 +5,7 @@ export type Order =
 
 export type OrderWithProduct =
   paths["/orders/{order_id}"]["get"]["responses"][200]["content"]["application/json"] & {
-    product: ProductInfo;
+    product?: ProductInfo;
   };
 
 export type ProductInfo = {
@@ -16,7 +16,10 @@ export type ProductInfo = {
   metadata: Record<string, string>;
 };
 
-export const orderStatuses = [
+export type OrderStatus =
+  paths["/orders/{order_id}"]["get"]["responses"][200]["content"]["application/json"]["order"]["status"];
+
+export const orderStatuses: OrderStatus[] = [
   "processing",
   "in_development",
   "being_assembled",

--- a/frontend/src/lib/types/routes.ts
+++ b/frontend/src/lib/types/routes.ts
@@ -82,6 +82,9 @@ const ROUTES = {
   // Link robot
   LINK: route("link"),
 
+  // Admin Dashboard
+  ADMIN: route("admin"),
+
   // Not found
   NOT_FOUND: route("404"),
 };

--- a/frontend/src/lib/utils/orders.ts
+++ b/frontend/src/lib/utils/orders.ts
@@ -1,0 +1,6 @@
+import type { OrderWithProduct } from "@/lib/types/orders";
+import { canModifyStatuses } from "@/lib/types/orders";
+
+export const canModifyOrder = (order: OrderWithProduct) => {
+  return canModifyStatuses.includes(order.order.status);
+};

--- a/store/app/routers/robots.py
+++ b/store/app/routers/robots.py
@@ -3,11 +3,9 @@
 import asyncio
 from typing import Self
 
-from annotated_types import MaxLen
 from boto3.dynamodb.conditions import Key
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ValidationError
-from typing_extensions import Annotated
 
 from store.app.crud.base import ItemNotFoundError
 from store.app.crud.robots import RobotData


### PR DESCRIPTION
**What does this PR do?**
1. Adds Admin only dashboard for managing orders (can be augmented for future use by other sellers)
2. Allows admins to change order status, process preorders (still somewhat WIP, and cancel orders (refunds user)
3. Made various `Order` related code more modular/reusable, better defined models and request/response types
4. Adjustable Modal size
5. General code clean up/improvements

**If this PR changes the UI, include a screenshot below.**
## Admin Manage Order dropdown menu options
<img width="1512" alt="Screenshot 2024-11-18 at 6 51 12 PM" src="https://github.com/user-attachments/assets/78f5204d-13a8-4590-8234-c22cacd24f1f">

## Update order status modal
<img width="720" alt="Screenshot 2024-11-18 at 6 12 06 PM" src="https://github.com/user-attachments/assets/df23077d-5469-4567-bc04-9beb7bfc2004">
<img width="720" alt="Screenshot 2024-11-18 at 6 12 08 PM" src="https://github.com/user-attachments/assets/aff0d7a8-d41f-4107-b997-85d1e556dbbc">

## Process Preorder modal
<img width="720" alt="Screenshot 2024-11-18 at 6 19 27 PM" src="https://github.com/user-attachments/assets/da2398f5-cea9-4f4b-9bb2-8e866323c724">

