### PR TITLE
Support for uploading kernel images via CLI

### DIFF
--- a/frontend/src/components/listing/ListingArtifactRenderer.tsx
+++ b/frontend/src/components/listing/ListingArtifactRenderer.tsx
@@ -20,6 +20,7 @@ const ListingArtifactRenderer = ({ artifact }: Props) => {
         />
       );
     case "tgz":
+    case "kernel":
       return (
         <div className="w-full h-full flex flex-col items-center justify-center gap-2">
           <Link

--- a/frontend/src/gen/api.ts
+++ b/frontend/src/gen/api.ts
@@ -1925,7 +1925,7 @@ export interface components {
             /** Name */
             name: string;
             /** Artifact Type */
-            artifact_type: "image" | ("urdf" | "mjcf") | ("stl" | "obj" | "dae" | "ply") | ("tgz" | "zip");
+            artifact_type: "image" | "kernel" | ("urdf" | "mjcf") | ("stl" | "obj" | "dae" | "ply") | ("tgz" | "zip");
             /** Description */
             description: string | null;
             /** Timestamp */
@@ -2459,7 +2459,7 @@ export interface operations {
             };
             header?: never;
             path: {
-                artifact_type: "image" | ("urdf" | "mjcf") | ("stl" | "obj" | "dae" | "ply") | ("tgz" | "zip");
+                artifact_type: "image" | "kernel" | ("urdf" | "mjcf") | ("stl" | "obj" | "dae" | "ply") | ("tgz" | "zip");
                 listing_id: string;
                 name: string;
             };

--- a/store/app/model.py
+++ b/store/app/model.py
@@ -7,7 +7,6 @@ expects (for example, converting a UUID into a string).
 
 import time
 from datetime import datetime, timedelta
-from pathlib import Path
 from typing import Literal, Self, cast, get_args
 
 from pydantic import BaseModel
@@ -228,37 +227,54 @@ SizeMapping: dict[ArtifactSize, tuple[int, int]] = {
 }
 
 
-def get_artifact_type(content_type: str | None, filename: str) -> ArtifactType:
-    """Gets the artifact type from the content type and filename."""
-    extension = Path(filename).suffix.lower()
-
-    if extension == ".img":
-        return "kernel"
-
-    if content_type and content_type.startswith("image/"):
-        return "image"
-
-    match extension:
-        case ".png" | ".jpg" | ".jpeg" | ".gif" | ".webp":
+def get_artifact_type(content_type: str | None, filename: str | None) -> ArtifactType:
+    if filename is not None:
+        extension = filename.split(".")[-1].lower()
+        if extension == "img":
+            return "kernel"
+        if extension in ("png", "jpeg", "jpg", "gif", "webp"):
             return "image"
-        case ".urdf":
+        if extension in ("urdf",):
             return "urdf"
-        case ".mjcf":
+        if extension in ("mjcf", "xml"):
             return "mjcf"
-        case ".stl":
+        if extension in ("stl",):
             return "stl"
-        case ".obj":
+        if extension in ("obj",):
             return "obj"
-        case ".dae":
+        if extension in ("dae",):
             return "dae"
-        case ".ply":
+        if extension in ("ply",):
             return "ply"
-        case ".tgz" | ".tar.gz":
+        if extension in ("tgz", "tar.gz"):
             return "tgz"
-        case ".zip":
+        if extension in ("zip",):
             return "zip"
-        case _:
-            raise ValueError(f"Unsupported file extension: {extension}")
+
+    # Attempts to determine from content type.
+    if content_type is not None:
+        if content_type in UPLOAD_CONTENT_TYPE_OPTIONS["kernel"]:
+            return "kernel"
+        if content_type in UPLOAD_CONTENT_TYPE_OPTIONS["image"]:
+            return "image"
+        if content_type in UPLOAD_CONTENT_TYPE_OPTIONS["urdf"]:
+            return "urdf"
+        if content_type in UPLOAD_CONTENT_TYPE_OPTIONS["mjcf"]:
+            return "mjcf"
+        if content_type in UPLOAD_CONTENT_TYPE_OPTIONS["stl"]:
+            return "stl"
+        if content_type in UPLOAD_CONTENT_TYPE_OPTIONS["obj"]:
+            return "obj"
+        if content_type in UPLOAD_CONTENT_TYPE_OPTIONS["dae"]:
+            return "dae"
+        if content_type in UPLOAD_CONTENT_TYPE_OPTIONS["ply"]:
+            return "ply"
+        if content_type in UPLOAD_CONTENT_TYPE_OPTIONS["tgz"]:
+            return "tgz"
+        if content_type in UPLOAD_CONTENT_TYPE_OPTIONS["zip"]:
+            return "zip"
+
+    raise ValueError(f"Unknown content type for file: {filename}")
 
 
 def get_compression_type(content_type: str | None, filename: str | None) -> CompressedArtifactType:

--- a/store/settings/environment.py
+++ b/store/settings/environment.py
@@ -42,7 +42,7 @@ class ArtifactSettings:
     large_image_size: tuple[int, int] = field(default=(1536, 1536))
     small_image_size: tuple[int, int] = field(default=(256, 256))
     min_bytes: int = field(default=16)
-    max_bytes: int = field(default=1536 * 1536 * 25)
+    max_bytes: int = field(default=2**30)
     quality: int = field(default=80)
     max_concurrent_file_uploads: int = field(default=3)
 


### PR DESCRIPTION
**What does this PR do?**

- Added support for users to upload kernel images their listing via CLI

Todo:
- Improve the UI in the frontend to delete the image and download (currently using URDF viewer UI)