### PR TITLE
Fix permission check for read-only API keys

### DIFF
--- a/store/app/model.py
+++ b/store/app/model.py
@@ -9,7 +9,7 @@ import time
 from datetime import datetime, timedelta
 from typing import Literal, Self, cast, get_args
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from store.app.errors import InternalError
 from store.app.utils.password import hash_password
@@ -151,6 +151,15 @@ class APIKey(StoreBaseModel):
     permissions: set[APIKeyPermission] | None = None
     ttl: int | None = None
     created_at: int
+
+    @field_validator("permissions", mode="before")
+    @classmethod
+    def convert_permissions_to_set(
+        cls, v: list[APIKeyPermission] | set[APIKeyPermission] | None
+    ) -> set[APIKeyPermission] | None:
+        if isinstance(v, list):
+            return set(v)
+        return v
 
     @classmethod
     def create(cls, user_id: str, source: APIKeySource, permissions: APIKeyPermissionSet) -> Self:

--- a/store/app/routers/teleop/webrtc.py
+++ b/store/app/routers/teleop/webrtc.py
@@ -11,7 +11,10 @@ from pydantic import BaseModel
 
 from store.app.db import Crud
 from store.app.model import TeleopICECandidate, User
-from store.app.security.user import get_session_user_with_write_permission
+from store.app.security.user import (
+    get_session_user_with_read_permission,
+    get_session_user_with_write_permission,
+)
 
 router = APIRouter()
 
@@ -84,7 +87,7 @@ class CheckAuthResponse(BaseModel):
 
 @router.get("/check", response_model=CheckAuthResponse)
 async def check_auth(
-    user: Annotated[User, Depends(get_session_user_with_write_permission)],
+    user: Annotated[User, Depends(get_session_user_with_read_permission)],
 ) -> CheckAuthResponse:
     """Validates the user's API key and returns their user ID."""
     return CheckAuthResponse(user_id=user.id)


### PR DESCRIPTION
**What does this PR do?**

Fixes 403 "Permission denied" errors when using read-only API keys on the /teleop/rtc/check endpoint.